### PR TITLE
resolve #519

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/LicenseManager.java
+++ b/dspace-api/src/main/java/org/dspace/core/LicenseManager.java
@@ -18,6 +18,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +35,7 @@ public class LicenseManager
 
     /** The default license */
     private static String license;
+
 
     /**
      * Writes license to a text file.
@@ -141,8 +145,9 @@ public class LicenseManager
      */
     private static void init()
     {
-        File licenseFile = new File(ConfigurationManager.getProperty("dspace.dir")
-                + File.separator + "config" + File.separator + "default.license");
+        String licensePath = new DSpace().getConfigurationService().getPropertyAsType("lr.license.default.path",
+                ConfigurationManager.getProperty("dspace.dir") + File.separator + "config" + File.separator + "default.license");
+        File licenseFile = new File(licensePath);
 
         FileInputStream  fir = null;
         InputStreamReader ir = null;

--- a/dspace/config/modules/lr.cfg
+++ b/dspace/config/modules/lr.cfg
@@ -270,10 +270,11 @@ shortener.handle.prefix = ${lr.shortener.handle.prefix}
 
 ####
 #
-# License branding (https://github.com/ufal/lindat-dspace/issues/289)
+# License branding (https://github.com/ufal/lindat-dspace/issues/289) , #519
 #
 ####
-license.alternative.path = ${dspace.dir}/config/alternative.license
+license.default.path = ${lr.default.license}
+license.alternative.path = ${lr.alternative.license}
 license.show_localized_explanation = true
 
 #build time

--- a/utilities/project_helpers/config/local.conf.dist
+++ b/utilities/project_helpers/config/local.conf.dist
@@ -376,6 +376,11 @@ lr.link.checker.read.timeout = 3000
 ### Entity ID of your shibboleth sp
 lr.spEntityId = http://example.com/sp/shibboleth
 
+### submission licenses
+lr.default.license = ${dspace.dir}/config/default.license
+lr.alternative.license = ${dspace.dir}/config/alternative.license
+
+
 #####
 #
 #  shortener


### PR DESCRIPTION
Resolves #519 by introducing config variables (local.properties) that set paths to default.license and alternative.license
equivalent of the current setup is:

```
lr.default.license = ${dspace.dir}/config/default.license
lr.alternative.license = ${dspace.dir}/config/alternative.license
```

default.license has `${dspace.dir}/config/default.license` as a default, but you at least have to introduce `lr.default.license =` (empty string) due to interpolation in lr.cfg
