### PR TITLE
minify all js and css under themes

### DIFF
--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -33,7 +33,7 @@
                     <attachClasses>true</attachClasses>
                     <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
                     <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
-                    <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
+                    <warSourceExcludes>WEB-INF/lib/*.jar,themes/**/*.css,themes/**/*.js</warSourceExcludes>
                     <webResources>
                         <resource>
                             <filtering>true</filtering>
@@ -70,6 +70,31 @@
                         <exclude>**/sc-mobile*</exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.samaxes.maven</groupId>
+                <artifactId>minify-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>minify</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>minify</goal>
+                        </goals>
+                        <configuration>
+                            <skipMerge>true</skipMerge>
+                            <nosuffix>true</nosuffix>
+                            <cssSourceDir>themes</cssSourceDir>
+                            <cssSourceIncludes>
+                                <cssSourceInclude>**/*.css</cssSourceInclude>
+                            </cssSourceIncludes>
+                            <jsSourceDir>themes</jsSourceDir>
+                            <jsSourceIncludes>
+                                <jsSourceInclude>**/*.js</jsSourceInclude>
+                            </jsSourceIncludes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/js/jquery.i18n.js
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/js/jquery.i18n.js
@@ -20,7 +20,7 @@
      * i18n property list
      */
     var i18n = {
-        default : 'en',
+        defaultLocale : 'en',
         //en is empty aka identity
         dicts: {en : {},},
 
@@ -33,7 +33,7 @@
          */
         load: function(locale, i18n_dict) {
             if(!locale){
-                locale = this.default;
+                locale = this.defaultLocale;
             }
             if (this.dicts[locale]) {
                 $.extend(this.dicts[locale], i18n_dict);
@@ -56,7 +56,7 @@
         _: function (str) {
             currentLocale = $("#ds-language-selection").attr("data-locale");
             if(!currentLocale){
-                currentLocale = this.default;
+                currentLocale = this.defaultLocale;
             }
             dict = this.dicts[currentLocale];
             if (dict && dict.hasOwnProperty(str)) {


### PR DESCRIPTION
resolves #657 

does not work on files in dspace/modules/xmlui... (ie. on overlays)
jquery.i18n.js: the minifier complained about default as an identifier