### PR TITLE
Conflict in versions of jboss-logging (fix #674)

### DIFF
--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
-        <jersey.version>2.21</jersey.version>
+        <jersey.version>2.25.1</jersey.version>
     </properties>
     <build>
         <plugins>
@@ -100,6 +100,10 @@
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-aop</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Resolves #674. A java.lang.NoSuchMethodError: org.jboss.logging.Logger.debugf(Ljava/lang/String;I)V was thrown; which prevented the download.
With jersey.version 2.21 org.jboss.logging classes are packed directly in bean-validator-2.4.0-b31.jar with 2.25.1 the dependencies are different so the older jboss-logging can be excluded.