### PR TITLE
resolves #469 (big downloads)

### DIFF
--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelEditConfigurationTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelEditConfigurationTab.java
@@ -1,0 +1,65 @@
+/* Created for LINDAT/CLARIN */
+package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
+
+import cz.cuni.mff.ufal.DSpaceApi;
+import org.apache.cocoon.environment.ObjectModelHelper;
+import org.apache.cocoon.environment.Request;
+import org.dspace.app.xmlui.aspect.administrative.controlpanel.AbstractControlPanelTab;
+import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.wing.WingException;
+import org.dspace.app.xmlui.wing.element.Division;
+import org.dspace.app.xmlui.wing.element.List;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.content.Site;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
+
+import java.sql.SQLException;
+import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class ControlPanelEditConfigurationTab extends AbstractControlPanelTab {
+
+	private static final Message T_DSPACE_HEAD = message("xmlui.administrative.ControlPanel.dspace_head");
+
+	@Override
+	public void addBody(Map objectModel, Division div) throws WingException, SQLException, AuthorizeException {
+		if (!AuthorizeManager.isAdmin(context))
+		{
+			throw new AuthorizeException("You are not authorized to view this page.");
+		}
+
+		ConfigurationService configuration = new DSpace().getConfigurationService();
+		div.addPara("alert", "alert alert-danger").addContent("Use at your own risk. This is only a call to ConfigurationService. It does not update values cached in any java class. ConfigurationManager is unaware of any value change.");
+
+		div = div.addInteractiveDivision("edit-config-form", this
+				.web_link, Division.METHOD_POST);
+		Request request = ObjectModelHelper.getRequest(objectModel);
+
+		String varName = request.getParameter("varName");
+		String varValue = "";
+
+		if(isNotBlank(varName) && "Show".equals(request.getParameter("submit-config-form"))){
+			varValue = configuration.getProperty(varName);
+		}
+
+		if(isNotBlank(varName) && "Set".equals(request.getParameter("submit-config-form"))){
+			varValue = request.getParameter("varValue");
+			configuration.setProperty(varName, varValue);
+		}
+
+		div.setHead(T_DSPACE_HEAD);
+		List list = div.addList("dspace");
+		list.addLabel("Property name");
+		list.addItem(null,null).addText("varName").setValue(varName);
+		list.addLabel("Property value");
+		list.addItem(null,null).addText("varValue").setValue(varValue);
+		list.addItem(null, null).addButton("submit-config-form").setValue("Show");
+		list.addItem(null, null).addButton("submit-config-form").setValue("Set");
+	}
+
+}
+

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
@@ -46,6 +46,7 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.disseminate.CitationDocument;
 import org.dspace.handle.HandleManager;
+import org.dspace.storage.bitstore.BitstreamStorageManager;
 import org.dspace.usage.UsageEvent;
 import org.dspace.utils.DSpace;
 import org.xml.sax.SAXException;
@@ -178,6 +179,10 @@ public class BitstreamReader extends AbstractReader implements Recyclable
     private File tempFile;
 
     private String redirectToURL;
+
+    private String XSendFileHeader;
+    private String XSendFilePathPrefix;
+    private String bitstreamPathRelativeToAssetstore;
 
     /**
      * Set up the bitstream reader.
@@ -442,6 +447,13 @@ public class BitstreamReader extends AbstractReader implements Recyclable
             } else {
             	this.redirectToURL = "";
             }
+
+            XSendFileHeader = ConfigurationManager.getProperty("lr","XSendFileHeader");
+            XSendFilePathPrefix = ConfigurationManager.getProperty("lr", "XSendFilePathPrefix");
+            XSendFilePathPrefix = XSendFilePathPrefix == null ? "" : XSendFilePathPrefix;
+            //assume only one assetstore
+            bitstreamPathRelativeToAssetstore = XSendFilePathPrefix + BitstreamStorageManager.getIntermediatePath(bitstream.get_internal_id()) +
+                    bitstream.get_internal_id();
         }
         catch (SQLException sqle)
         {
@@ -796,7 +808,16 @@ public class BitstreamReader extends AbstractReader implements Recyclable
 
         try
         {
-            if(org.apache.commons.lang3.StringUtils.isNotBlank(this.redirectToURL)){
+            if(org.apache.commons.lang3.StringUtils.isNotBlank(this.XSendFileHeader)){
+                //path should take into the account the nginx inner location (eg. alias for .../assetstore)
+                //or what you allow in apache with XSendFilePath
+                //this is a header only response, could do even without opening in/out streams
+                //any authorization is handled during setup
+                //other headers (mime-type, content-dipsosition, ...) not changed
+                response.setHeader(this.XSendFileHeader, this.bitstreamPathRelativeToAssetstore);
+
+            }
+            else if(org.apache.commons.lang3.StringUtils.isNotBlank(this.redirectToURL)){
                 response.sendRedirect(this.redirectToURL);
             }else {
                 if (byteRange != null) {
@@ -881,6 +902,9 @@ public class BitstreamReader extends AbstractReader implements Recyclable
         this.tempFile = null;
         this.item = null;
         this.redirectToURL = null;
+        this.XSendFileHeader = null;
+        this.XSendFilePathPrefix = null;
+        this.bitstreamPathRelativeToAssetstore = null;
         super.recycle();
     }
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
@@ -448,8 +448,8 @@ public class BitstreamReader extends AbstractReader implements Recyclable
             	this.redirectToURL = "";
             }
 
-            XSendFileHeader = ConfigurationManager.getProperty("lr","XSendFileHeader");
-            XSendFilePathPrefix = ConfigurationManager.getProperty("lr", "XSendFilePathPrefix");
+            XSendFileHeader = new DSpace().getConfigurationService().getProperty("lr.XSendFileHeader");
+            XSendFilePathPrefix = new DSpace().getConfigurationService().getProperty("lr.XSendFilePathPrefix");
             XSendFilePathPrefix = XSendFilePathPrefix == null ? "" : XSendFilePathPrefix;
             //assume only one assetstore
             bitstreamPathRelativeToAssetstore = XSendFilePathPrefix + BitstreamStorageManager.getIntermediatePath(bitstream.get_internal_id()) +

--- a/dspace/config/modules/controlpanel.cfg
+++ b/dspace/config/modules/controlpanel.cfg
@@ -31,7 +31,8 @@ controlpanel.tabs = Java Information, \
                      Specific Metadata, \
                      Metadata Quality, \
                      Embargoed items, \
-                     Oldest users
+                     Oldest users, \
+                     Edit Configuration
 					
 
 
@@ -64,8 +65,9 @@ plugin.named.org.dspace.app.xmlui.aspect.administrative.controlpanel.ControlPane
 		cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative.ControlPanelMetadata = Specific Metadata, \
 		cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative.ControlPanelMetadataQA = Metadata Quality, \
 		cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative.ControlPanelEmbargo = Embargoed items, \
-		cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative.ControlPanelLastLogin = Oldest users
-		
+		cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative.ControlPanelLastLogin = Oldest users, \
+		cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative.ControlPanelEditConfigurationTab = Edit Configuration
+
 controlpanel.checks = 	Checks, \
 						Verify Logging, \
 						Dspace Log(s), \

--- a/dspace/config/modules/lr.cfg
+++ b/dspace/config/modules/lr.cfg
@@ -276,5 +276,14 @@ shortener.handle.prefix = ${lr.shortener.handle.prefix}
 license.alternative.path = ${dspace.dir}/config/alternative.license
 license.show_localized_explanation = true
 
+#####
+#
+# XSendFile header
+#
+####
+XSendFileHeader = ${lr.XSendFileHeader}
+XSendFilePathPrefix = ${lr.XSendFilePathPrefix}
+
+
 #build time
 ufal.build_time=${lr.compile.time}

--- a/utilities/project_helpers/config/local.conf.dist
+++ b/utilities/project_helpers/config/local.conf.dist
@@ -384,4 +384,12 @@ lr.spEntityId = http://example.com/sp/shibboleth
 lr.shortener.enabled = false
 lr.shortener.handle.prefix = 1234
 
+#####
+#
+# XSendFile header
+#
+####
+lr.XSendFileHeader =
+lr.XSendFilePathPrefix =
+
 lr.compile.time=


### PR DESCRIPTION
This PR resolves big downloads from #469. It makes it possible to serve bitstreams by webserver using XSendFile; see https://github.com/ufal/clarin-dspace/wiki/Speeding-up-downloads for configuration details.

A new control panel tab is added that let's you tweak/turn off the functionality.