### PR TITLE
Fix #613

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
@@ -34,6 +34,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.browse.BrowseException;
 import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
 import org.dspace.rest.common.Collection;
 import org.dspace.rest.common.Item;
 import org.dspace.rest.common.MetadataEntry;
@@ -336,9 +337,9 @@ public class CollectionsResource extends Resource
         {
             context = createContext(getUser(headers));
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId,
-                    org.dspace.core.Constants.WRITE);
+                    org.dspace.core.Constants.ADD);
 
-            writeStats(dspaceCollection, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,
+            writeStats(dspaceCollection, UsageEvent.Action.ADD, user_ip, user_agent, xforwardedfor,
                     headers, request, context);
 
             log.trace("Creating item in collection(id=" + collectionId + ").");
@@ -579,7 +580,7 @@ public class CollectionsResource extends Resource
         {
             context = createContext(getUser(headers));
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId,
-                    org.dspace.core.Constants.WRITE);
+                    Constants.REMOVE);
 
             org.dspace.content.Item item = null;
             org.dspace.content.ItemIterator dspaceItems = dspaceCollection.getItems();
@@ -597,19 +598,6 @@ public class CollectionsResource extends Resource
                 context.abort();
                 log.warn("Item(id=" + itemId + ") was not found!");
                 throw new WebApplicationException(Response.Status.NOT_FOUND);
-            }
-            else if (!AuthorizeManager.authorizeActionBoolean(context, item, org.dspace.core.Constants.REMOVE))
-            {
-                context.abort();
-                if (context.getCurrentUser() != null)
-                {
-                    log.error("User(" + context.getCurrentUser().getEmail() + ") has not permission to delete item!");
-                }
-                else
-                {
-                    log.error("User(anonymous) has not permission to delete item!");
-                }
-                throw new WebApplicationException(Response.Status.UNAUTHORIZED);
             }
 
             writeStats(dspaceCollection, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,

--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -494,7 +494,10 @@ public class ItemsResource extends Resource
                 dspaceBitstream.setDescription(description);
             }
 
+            //or we would need to add/remove ResourcePolicy (as in WorkspaceItem...AuthorizeManager.addPolicy(c, i, Constants.WRITE, e, ResourcePolicy.TYPE_SUBMISSION);)
+            context.turnOffAuthorisationSystem();
             dspaceBitstream.update();
+            context.restoreAuthSystemState();
 
             // Create policy for bitstream
             if (groupId != null)

--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -450,7 +450,7 @@ public class ItemsResource extends Resource
         try
         {
             context = createContext(getUser(headers));
-            org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.WRITE);
+            org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.ADD);
 
             writeStats(dspaceItem, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers, request, context);
 


### PR DESCRIPTION
Fixes #613 - makes it possible to create items and add bitstreams through rest api as non admin; there are no checks on the metadata (can go without author or license).

For this to work correctly, fix for #674 needs to be deployed. Also #614 might cause trouble on the first submission attempt after login