### PR TITLE
resolves #614

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/BitstreamResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/BitstreamResource.java
@@ -36,7 +36,6 @@ import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.BitstreamFormat;
-import org.dspace.content.Bundle;
 import org.dspace.eperson.Group;
 import org.dspace.rest.common.Bitstream;
 import org.dspace.rest.common.ResourcePolicy;
@@ -97,7 +96,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.READ);
 
             writeStats(dspaceBitstream, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers,
@@ -150,7 +149,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.READ);
             AuthorizeManager.getPolicies(context, dspaceBitstream);
 
@@ -212,7 +211,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Bitstream[] dspaceBitstreams = org.dspace.content.Bitstream.findAll(context);
 
             if (!((limit != null) && (limit >= 0) && (offset != null) && (offset >= 0)))
@@ -295,7 +294,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.READ);
 
             writeStats(dspaceBitstream, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers,
@@ -367,7 +366,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceBitstream, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers,
@@ -437,7 +436,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceBitstream, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,
@@ -539,7 +538,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceBitstream, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,
@@ -623,7 +622,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.DELETE);
 
             writeStats(dspaceBitstream, UsageEvent.Action.DELETE, user_ip, user_agent, xforwardedfor,
@@ -689,7 +688,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceBitstream, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers,

--- a/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
@@ -96,7 +96,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId, org.dspace.core.Constants.READ);
             writeStats(dspaceCollection, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor,
@@ -165,7 +165,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             if (!((limit != null) && (limit >= 0) && (offset != null) && (offset >= 0)))
             {
@@ -251,7 +251,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId, org.dspace.core.Constants.READ);
             writeStats(dspaceCollection, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor,
@@ -334,7 +334,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId,
                     org.dspace.core.Constants.WRITE);
 
@@ -434,7 +434,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId,
                     org.dspace.core.Constants.WRITE);
 
@@ -506,7 +506,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId,
                     org.dspace.core.Constants.DELETE);
 
@@ -577,7 +577,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId,
                     org.dspace.core.Constants.WRITE);
 
@@ -674,7 +674,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Collection[] dspaceCollections;
 
             dspaceCollections = org.dspace.content.Collection.findAll(context);

--- a/dspace-rest/src/main/java/org/dspace/rest/CommunitiesResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CommunitiesResource.java
@@ -83,7 +83,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             org.dspace.content.Community dspaceCommunity = findCommunity(context, communityId, org.dspace.core.Constants.READ);
             writeStats(dspaceCommunity, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers,
@@ -149,7 +149,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             org.dspace.content.Community[] dspaceCommunities = org.dspace.content.Community.findAll(context);
             communities = new ArrayList<Community>();
@@ -231,7 +231,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             org.dspace.content.Community[] dspaceCommunities = org.dspace.content.Community.findAllTop(context);
             communities = new ArrayList<Community>();
@@ -313,7 +313,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             org.dspace.content.Community dspaceCommunity = findCommunity(context, communityId, org.dspace.core.Constants.READ);
             writeStats(dspaceCommunity, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers,
@@ -399,7 +399,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             org.dspace.content.Community dspaceCommunity = findCommunity(context, communityId, org.dspace.core.Constants.READ);
             writeStats(dspaceCommunity, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers,
@@ -474,7 +474,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             if (!AuthorizeManager.isAdmin(context))
             {
@@ -559,7 +559,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Community dspaceCommunity = findCommunity(context, communityId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceCommunity, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,
@@ -643,7 +643,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Community dspaceParentCommunity = findCommunity(context, communityId,
                     org.dspace.core.Constants.WRITE);
 
@@ -722,7 +722,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             org.dspace.content.Community dspaceCommunity = findCommunity(context, communityId, org.dspace.core.Constants.WRITE);
             writeStats(dspaceCommunity, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,
@@ -789,7 +789,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             org.dspace.content.Community community = findCommunity(context, communityId, org.dspace.core.Constants.DELETE);
             writeStats(community, UsageEvent.Action.DELETE, user_ip, user_agent, xforwardedfor, headers,
@@ -859,7 +859,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             org.dspace.content.Community community = findCommunity(context, communityId, org.dspace.core.Constants.WRITE);
             org.dspace.content.Collection collection = null;
@@ -965,7 +965,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             org.dspace.content.Community parentCommunity = findCommunity(context, parentCommunityId,
                     org.dspace.core.Constants.WRITE);

--- a/dspace-rest/src/main/java/org/dspace/rest/HandleResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/HandleResource.java
@@ -13,7 +13,6 @@ import cz.cuni.mff.ufal.dspace.rest.FeaturedServices;
 import cz.cuni.mff.ufal.dspace.rest.RefBoxData;
 import cz.cuni.mff.ufal.dspace.rest.citation.formats.AbstractFormat;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.Metadatum;
@@ -31,21 +30,16 @@ import se.kb.oai.pmh.ErrorResponseException;
 import se.kb.oai.pmh.OaiPmhServer;
 import se.kb.oai.pmh.Record;
 
-import javax.security.auth.login.Configuration;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
 
 import java.io.IOException;
 import java.net.URL;
 import java.sql.SQLException;
-
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 /**
  * Created with IntelliJ IDEA.
@@ -68,7 +62,7 @@ public class HandleResource extends Resource {
         DSpaceObject result = null;
 
         try {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             org.dspace.content.DSpaceObject dso = HandleManager.resolveToObject(context, prefix + "/" + suffix);
             if(dso == null) {
@@ -115,7 +109,7 @@ public class HandleResource extends Resource {
                                                 @Context HttpHeaders headers) throws WebApplicationException {
         org.dspace.core.Context context = null;
         try {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.DSpaceObject dso = HandleManager.resolveToObject(context, prefix + "/" + suffix);
             if (dso == null || dso.getType() != Constants.ITEM) {
                 context.complete();
@@ -166,7 +160,7 @@ public class HandleResource extends Resource {
                                          @Context HttpHeaders headers) throws WebApplicationException {
         org.dspace.core.Context context = null;
         try {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.DSpaceObject dso = HandleManager.resolveToObject(context, prefix + "/" + suffix);
             if (dso == null || dso.getType() != Constants.ITEM) {
                 context.complete();
@@ -190,7 +184,7 @@ public class HandleResource extends Resource {
                                @Context HttpHeaders headers) throws WebApplicationException {
         org.dspace.core.Context context = null;
         try {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.DSpaceObject dso = HandleManager.resolveToObject(context, prefix + "/" + suffix);
             if (dso == null || dso.getType() != Constants.ITEM) {
                 context.complete();

--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -103,7 +103,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.READ);
 
             writeStats(dspaceItem, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -163,7 +163,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             ItemIterator dspaceItems = org.dspace.content.Item.findAllUnfiltered(context);
             items = new ArrayList<Item>();
@@ -239,7 +239,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.READ);
 
             writeStats(dspaceItem, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -298,7 +298,7 @@ public class ItemsResource extends Resource
         List<Bitstream> bitstreams = null;
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.READ);
 
             writeStats(dspaceItem, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -369,7 +369,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceItem, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -449,7 +449,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceItem, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -617,7 +617,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceItem, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -699,7 +699,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.DELETE);
 
             writeStats(dspaceItem, UsageEvent.Action.REMOVE, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -768,7 +768,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceItem, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -849,7 +849,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
             org.dspace.content.Item item = findItem(context, itemId, org.dspace.core.Constants.WRITE);
 
             org.dspace.content.Bitstream bitstream = org.dspace.content.Bitstream.find(context, bitstreamId);
@@ -861,8 +861,8 @@ public class ItemsResource extends Resource
             }
             else if (!AuthorizeManager.authorizeActionBoolean(context, bitstream, org.dspace.core.Constants.DELETE))
             {
+                log.error("User(" + context.getCurrentUser().getEmail() + ") is not allowed to delete bitstream(id=" + bitstreamId + ").");
                 context.abort();
-                log.error("User(" + getUser(headers).getEmail() + ") is not allowed to delete bitstream(id=" + bitstreamId + ").");
                 return Response.status(Status.UNAUTHORIZED).build();
             }
 
@@ -950,7 +950,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(headers);
 
             // TODO Repair, it ends by error:
             // "java.sql.SQLSyntaxErrorException: ORA-00932: inconsistent datatypes: expected - got CLOB"

--- a/dspace-rest/src/main/java/org/dspace/rest/Resource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/Resource.java
@@ -11,7 +11,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
@@ -54,9 +53,8 @@ public class Resource
      * a problem with authorization to read from the database. Throws Exception
      * if there was a problem creating context.
      * 
-     * @param person
-     *            User which will be logged in context.
-     * @return Newly created context with the logged in user unless the specified user was null.
+     *
+     * @param httpHeaders@return Newly created context with the logged in user unless the specified user was null.
      *         If user is null, create the context without a logged in user.
      * @throws ContextException
      *             Thrown in case of a problem creating context. Can be caused by
@@ -64,7 +62,7 @@ public class Resource
      *             log in. Can be caused by AuthorizeException if there was a
      *             problem authorizing the found user.
      */
-    protected static org.dspace.core.Context createContext(EPerson person) throws ContextException
+    protected static org.dspace.core.Context createContext(HttpHeaders httpHeaders) throws ContextException
     {
 
         org.dspace.core.Context context = null;
@@ -73,6 +71,7 @@ public class Resource
         {
             context = new org.dspace.core.Context();
             context.getDBConnection().setAutoCommit(false); // Disable autocommit.
+            EPerson person = getUser(context, httpHeaders);
 
             if (person != null)
             {
@@ -242,14 +241,12 @@ public class Resource
      * @return Return EPerson logged under token in headers. If token was wrong
      *         or header rest-dspace-token was missing, returns null.
      */
-    protected static EPerson getUser(HttpHeaders headers)
+    protected static EPerson getUser(org.dspace.core.Context context, HttpHeaders headers)
     {
-        List<String> list = headers.getRequestHeader(TokenHolder.TOKEN_HEADER);
-        String token = null;
-        if ((list != null) && (list.size() > 0))
+        String token = getToken(headers);
+        if (token != null)
         {
-            token = list.get(0);
-            return TokenHolder.getEPerson(token);
+            return TokenHolder.getEPerson(context, token);
         }
         return null;
     }

--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -172,11 +172,11 @@ public class RestIndex {
         List<String> list = headers.getRequestHeader(TokenHolder.TOKEN_HEADER);
         String token = null;
         boolean logout = false;
-        EPerson ePerson = null;
+        String ePersonMail = null;
         if (list != null)
         {
             token = list.get(0);
-            ePerson = TokenHolder.getEPerson(token);
+            ePersonMail = TokenHolder.getEMail(token);
             logout = TokenHolder.logout(token);
         }
         if ((token == null) || (!logout))
@@ -184,8 +184,8 @@ public class RestIndex {
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
 
-        if(ePerson != null) {
-            log.info("REST Logout: " + ePerson.getEmail());
+        if(ePersonMail != null) {
+            log.info("REST Logout: " + ePersonMail);
         }
         return Response.ok().build();
     }
@@ -207,24 +207,18 @@ public class RestIndex {
         org.dspace.core.Context context = null;
 
         try {
-            context = Resource.createContext(Resource.getUser(headers));
+            context = Resource.createContext(headers);
             EPerson ePerson = context.getCurrentUser();
 
             if(ePerson != null) {
-                //DB EPerson needed since token won't have full info, need context
-                EPerson dbEPerson = EPerson.findByEmail(context, ePerson.getEmail());
                 String token = Resource.getToken(headers);
-                Status status = new Status(dbEPerson.getEmail(), dbEPerson.getFullName(), token);
+                Status status = new Status(ePerson.getEmail(), ePerson.getFullName(), token);
                 return status;
             }
 
         } catch (ContextException e)
         {
             Resource.processException("Status context error: " + e.getMessage(), context);
-        } catch (SQLException e) {
-            Resource.processException("Status eperson db lookup error: " + e.getMessage(), context);
-        } catch (AuthorizeException e) {
-            Resource.processException("Status eperson authorize exception: " + e.getMessage(), context);
         } finally {
             context.abort();
         }


### PR DESCRIPTION
Resolves #614. The TokenHolder was keeping a list of EPerson, but each of those had a closed connection. Meaning that first time you try to fetch name of the eperson NPE is thrown and a null value is cached. On further fetches the cached null is returned