### PR TITLE
Resolves #663 - Use REST API instead of solr rewrite/JSON in autocomplete

### DIFF
--- a/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/Application.java
+++ b/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/Application.java
@@ -1,9 +1,14 @@
 package cz.cuni.mff.ufal.dspace.rest;
 
+import org.glassfish.jersey.message.GZipEncoder;
+import org.glassfish.jersey.message.filtering.EntityFilteringFeature;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.filter.EncodingFilter;
 
 public class Application extends ResourceConfig{
     public Application(){
         packages("org.dspace.rest","cz.cuni.mff.ufal.dspace.rest");
+        register(EntityFilteringFeature.class);
+        EncodingFilter.enableFor(this, GZipEncoder.class);
     }
 }

--- a/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/Suggestions.java
+++ b/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/Suggestions.java
@@ -32,7 +32,6 @@ public class Suggestions extends Resource {
         Context context = null;
         try{
             context = new Context(Context.READ_ONLY);
-            //?q=*:*&rows=0&facet=on&wt=json&indent=true&facet.limit=-1&facet.field=$1
             JSONStream = searchService.searchJSON(context, queryArgs, null);
             context.complete();
         }catch (SearchServiceException | SQLException e){

--- a/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/Suggestions.java
+++ b/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/Suggestions.java
@@ -1,0 +1,46 @@
+package cz.cuni.mff.ufal.dspace.rest;
+
+import org.dspace.core.Context;
+import org.dspace.discovery.DiscoverFacetField;
+import org.dspace.discovery.DiscoverQuery;
+import org.dspace.discovery.SearchService;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.discovery.configuration.DiscoveryConfigurationParameters;
+import org.dspace.rest.Resource;
+import org.dspace.utils.DSpace;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.InputStream;
+import java.sql.SQLException;
+
+@Path("/suggestions")
+public class Suggestions extends Resource {
+
+    @GET
+    @Path("/{facetField}")
+    @Produces({MediaType.APPLICATION_JSON})
+    public Response getSuggestion(@PathParam("facetField") String facetField){
+        DiscoverQuery queryArgs = new DiscoverQuery();
+        queryArgs.setQuery("*:*");
+        int facetLimit = -1;
+        //Using the api that's there; we don't actually need "real" DiscoverFacetField object; TYPE_STANDARD should not modify the facetField, but TYPE_AC would add "_ac"
+        queryArgs.addFacetField(new DiscoverFacetField(facetField, DiscoveryConfigurationParameters.TYPE_STANDARD, facetLimit, DiscoveryConfigurationParameters.SORT.COUNT));
+        SearchService searchService = new DSpace().getServiceManager().getServiceByName(SearchService.class.getName(), SearchService.class);
+        InputStream JSONStream = null;
+        Context context = null;
+        try{
+            context = new Context(Context.READ_ONLY);
+            //?q=*:*&rows=0&facet=on&wt=json&indent=true&facet.limit=-1&facet.field=$1
+            JSONStream = searchService.searchJSON(context, queryArgs, null);
+            context.complete();
+        }catch (SearchServiceException | SQLException e){
+            processException("Error while retrieving JSON from discovery. " + e.getMessage(), context);
+        }finally {
+            processFinally(context);
+        }
+        return Response.ok(JSONStream).build();
+    }
+}
+

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/bootstrap/js/ufal.min.js
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/bootstrap/js/ufal.min.js
@@ -602,10 +602,12 @@ ufal.submissions = {
                 break;
             }
         }
-        if (data != null) {
+        if (data instanceof Array) {
             for (var i = 0; i < data.length; i += 2) {
                 values[data[i]] = data[i + 1];
             }
+        } else if (data instanceof Object) {
+            values = data;
         } else {
             console.log(
                 "lindat/autocomplete failed to load data: did not get correct solr json");


### PR DESCRIPTION
Resolves #663 - adds `/rest/suggestions/{facetField}` endpoint, that behaves more or less as the rewrite we've used for autocomplete. Meaning it's still based on solr, it still returns all the facet fields (actually the rewrite in wiki is missing `facet.limit=-1` so it was not behaving as expected), the autocomplete in submission and on search page are still separated, but both are now using `SearchService.searchJSON`.

The major benefit of this is less clutter in web server config (and easier propagation of fixes to issues such as the above mentioned missing `facet.limit=-1`).

To drop the rewrite, just change `lr.autocomplete.solr.url` to `.../rest/suggestions/`. Both the old (rewrite) and new approaches should be working. They differ only in the autocomplete url.

GZipping of responses was made available for all rest endpoints