### PR TITLE
Resolves #627 - Authorisation via federated login

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/Headers.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/Headers.java
@@ -110,8 +110,8 @@ public class Headers
                 // prevent an endless loop in an error condition.
             	header = header.substring(1,header.length());
 
-            } else if (idx > 0 && header.charAt(idx-1) != '\\' ) {
-                // The attribute starts with an escaped semicolon
+            } else if (idx > 0 && header.charAt(idx-1) == '\\' ) {
+                // found an escaped semicolon; move on
                 idx++;
             } else if ( idx > 0) {
                 // First extract the value and store it on the list.

--- a/dspace/config/modules/authentication-shibboleth.cfg
+++ b/dspace/config/modules/authentication-shibboleth.cfg
@@ -201,3 +201,13 @@ default.auth.group = Authenticated
 role.ufal.mff.cuni.cz = UFAL
 
 spEntityId = ${lr.spEntityId}
+
+#attribute -> group mapping
+#check shibboleth attribute ATTR and put users having value ATTR_VALUE1 and ATTR_VALUE2 to GROUP1
+#users having ATTR_VALUE3 to GROUP2
+#groups must exist
+#header.ATTR=ATTR_VALUE1=>GROUP1,ATTR_VALUE2=>GROUP1,ATTR_VALUE3=>GROUP2
+#examples:
+#header.entitlement = staff@org1297.mff.cuni.cz => UFAL_MEMBER, urn:cuni:affiliation:staff@mff.cuni.cz => CUNI_STAFF,\
+#                     urn:mace:eduid.cz:affiliation:interrupted-student => INTERRUPTED_STUDENTS
+#header.unscoped-affiliation = member => MEMBERS, staff=> STAFF, employee => EMPLOYEES, alum => ALUMS


### PR DESCRIPTION
Resolves #627; allows to add shibboleth attribute value to group mappings.
The original dspace role header mapping (as described in https://wiki.duraspace.org/display/DSDOC5x/Authentication+Plugins#AuthenticationPlugins-ShibbolethAuthentication) are left intact; now you can also add mapping for other attributes. Put your definitions in authentication-shibboleth.cfg; there are examples of the format in that file. The groups you map to must already exist (otherwise we wouldn't know what permissions apply to them)