### PR TITLE
fixes #752 - Bitstreams added through rest don't trigger item.update

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -554,6 +554,8 @@ public class ItemsResource extends Resource
 
             dspaceBitstream = org.dspace.content.Bitstream.find(context, dspaceBitstream.getID());
             bitstream = new Bitstream(dspaceBitstream, "");
+            //trigger auto generated metadata on item
+            dspaceItem.update();
 
             context.complete();
 


### PR DESCRIPTION
fixes #752 - Bitstreams added through rest don't trigger item.update