### PR TITLE
Resolves #757 - add PID into item view (explicitly) and copyable

### DIFF
--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -2644,6 +2644,7 @@
 
     <message key="xmlui.ufal.METS-1.0.item-collections">Collection(s)</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-relation-isreferencedby">Referenced by</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-pid">Item identifier</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
     <message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">KB</message>

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -233,9 +233,32 @@
 				</xsl:call-template>
 			</xsl:when>
 
+			<!-- PID row -->
+			<xsl:when test="$clause = 4 and (dim:field[@element='identifier' and @qualifier='uri'])">
+				<dl id="item-pid" class="dl-horizontal" style="clear:both;">
+                    <dt style="text-align: left">
+                        <i class="fa fa-share">&#160;</i>
+                        <span><i18n:text>PID</i18n:text></span>
+                    </dt>
+                    <dd style="padding-right: 40px;">
+                        <a id="item_pid">
+                            <xsl:attribute name="href">
+                                <xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']" />
+                            </xsl:attribute>
+                            <xsl:value-of select="dim:field[@element='identifier' and @qualifier='uri']" />
+                        </a>
+                        <button class="repo-copy-btn pull-right" data-clipboard-target="#item_pid" />
+                    </dd>
+				</dl>
+				<xsl:call-template name="itemSummaryView-DIM-fields">
+					<xsl:with-param name="clause" select="($clause + 1)" />
+					<xsl:with-param name="phase" select="$otherPhase" />
+				</xsl:call-template>
+			</xsl:when>
+
 			<!-- Project URL(s) row -->
 			<xsl:when
-				test="$clause = 4 and dim:field[@element='source'][@qualifier='uri']">
+				test="$clause = 5 and dim:field[@element='source'][@qualifier='uri']">
 						<dl id="project-url" class="dl-horizontal">
 							<dt style="text-align: left">
 								<i class="fa fa-link">&#160;</i>
@@ -268,7 +291,7 @@
 
 			<!-- Demo URL(s) row -->
 			<xsl:when
-				test="$clause = 5 and dim:field[@mdschema='local' and @element='demo' and @qualifier='uri']">
+				test="$clause = 6 and dim:field[@mdschema='local' and @element='demo' and @qualifier='uri']">
 						<dl id="demo-url" class="dl-horizontal">
 							<dt style="text-align: left">
 								<i class="fa fa-external-link">&#160;</i>
@@ -301,7 +324,7 @@
 
 			<!-- referenced by -->
 			<xsl:when
-					test="$clause = 6 and dim:field[@element='relation'][@qualifier='isreferencedby']">
+					test="$clause = 7 and dim:field[@element='relation'][@qualifier='isreferencedby']">
 				<dl id="relation-isreferencedby" class="dl-horizontal">
 					<dt style="text-align: left">
 						<i class="fa fa-link">&#160;</i>
@@ -334,7 +357,7 @@
 
 			<!-- date.issued row -->
 			<xsl:when
-				test="$clause = 7 and (dim:field[@element='date' and @qualifier='issued'])">
+				test="$clause = 8 and (dim:field[@element='date' and @qualifier='issued'])">
 				<dl id="date-issued" class="dl-horizontal">
 					<dt style="text-align: left">
 						<i class="fa fa-calendar">&#160;</i>					
@@ -358,7 +381,7 @@
 
 			<!-- type row -->
 			<xsl:when
-				test="$clause = 8 and (dim:field[@element='type' and not(@qualifier)])">
+				test="$clause = 9 and (dim:field[@element='type' and not(@qualifier)])">
 					<dl id="item-type" class="dl-horizontal">
 					<dt style="text-align: left">
 						<i class="fa fa-tag">&#160;</i>
@@ -378,7 +401,7 @@
 			</xsl:when>				
 
 			<!-- size row -->
-			<xsl:when test="$clause = 9">
+			<xsl:when test="$clause = 10">
 					<xsl:variable name="sizeInfo">
 						<xsl:choose>
 							<xsl:when test="dim:field[@mdschema='local' and @element='size' and @qualifier='info'][1]/node()">
@@ -421,7 +444,7 @@
 
 			<!-- type languages -->
 			<xsl:when
-				test="$clause = 10 and (dim:field[@element='language' and @qualifier='iso'])">
+				test="$clause = 11 and (dim:field[@element='language' and @qualifier='iso'])">
 					<dl id="item-languages" class="dl-horizontal">
 					<dt style="text-align: left">
 						<i class="fa fa-flag ">&#160;</i>
@@ -500,7 +523,7 @@
 
 			<!-- Description row -->
 			<xsl:when
-				test="$clause = 11 and (dim:field[@element='description' and not(@qualifier)])">
+				test="$clause = 12 and (dim:field[@element='description' and not(@qualifier)])">
 				<dl id="item-description" class="dl-horizontal linkify">
 					<dt style="text-align: left">
 						<i class="fa fa-file-text-o">&#160;</i>
@@ -533,7 +556,7 @@
 			
 			<!-- Publisher row -->
 			<xsl:when
-				test="$clause = 12 and (dim:field[@element='publisher' and not(@qualifier)])">
+				test="$clause = 13 and (dim:field[@element='publisher' and not(@qualifier)])">
 				<dl id="item-publisher" class="dl-horizontal">
 					<dt style="text-align: left">
 						<i class="fa fa-copy">&#160;</i>
@@ -565,7 +588,7 @@
 
 			<!-- Sponsors row -->
 			<xsl:when
-				test="$clause = 13 and ((dim:field[@element='sponsor' and not(@qualifier)]) or (dim:field[@element='ResourceInfo#ResourceCreationInfo#FundingInfo#ProjectInfo'] and dim:field[@qualifier='projectName']))">
+				test="$clause = 14 and ((dim:field[@element='sponsor' and not(@qualifier)]) or (dim:field[@element='ResourceInfo#ResourceCreationInfo#FundingInfo#ProjectInfo'] and dim:field[@qualifier='projectName']))">
 				<dl id="item-sponsor" class="dl-horizontal">
 					<dt style="text-align: left">
 						<i class="fa fa-money">&#160;</i>
@@ -636,7 +659,7 @@
 			
 			<!-- Subject keywords -->
 			<xsl:when
-				test="$clause = 14 and (dim:field[@element='subject' and not(@qualifier)])">
+				test="$clause = 15 and (dim:field[@element='subject' and not(@qualifier)])">
 				<dl id="item-subject" class="dl-horizontal">
 					<dt style="text-align: left">
 						<i class="fa fa-tags">&#160;</i>
@@ -662,7 +685,7 @@
 			
 			<!-- Collections -->
   			<xsl:when
-				test="$clause = 15 and $ufal-collection-references">
+				test="$clause = 16 and $ufal-collection-references">
 				<dl id="item-subject" class="dl-horizontal">
 					<dt style="text-align: left">
 						<i class="fa fa-sitemap">&#160;</i>
@@ -687,7 +710,7 @@
 				</xsl:call-template>
 			</xsl:when>
 
-			<xsl:when test="$clause = 16 and $ds_item_view_toggle_url != ''">
+			<xsl:when test="$clause = 17 and $ds_item_view_toggle_url != ''">
 
                 <!-- replacedby info -->
                 <xsl:if test="count(dim:field[@element='relation' and @qualifier='isreplacedby' and @mdschema='dc']) &gt;= 1">
@@ -734,7 +757,7 @@
 			<!-- recurse without changing phase if we didn't output anything -->
 			<xsl:otherwise>
 				<!-- IMPORTANT: This test should be updated if clauses are added! -->
-				<xsl:if test="$clause &lt; 16">
+				<xsl:if test="$clause &lt; 17">
 					<xsl:call-template name="itemSummaryView-DIM-fields">
 						<xsl:with-param name="clause" select="($clause + 1)" />
 						<xsl:with-param name="phase" select="$phase" />

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -238,7 +238,7 @@
 				<dl id="item-pid" class="dl-horizontal" style="clear:both;">
                     <dt style="text-align: left">
                         <i class="fa fa-share">&#160;</i>
-                        <span><i18n:text>PID</i18n:text></span>
+                        <span><i18n:text>xmlui.dri2xhtml.METS-1.0.item-pid</i18n:text></span>
                     </dt>
                     <dd style="padding-right: 40px;">
                         <a id="item_pid">

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -2661,6 +2661,7 @@
 
 	<message key="xmlui.ufal.METS-1.0.item-collections">Kolekce</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-relation-isreferencedby">Odkaz na záznam&#160;v</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-pid">Identifikátor</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">{0} bajtů</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">KB</message>


### PR DESCRIPTION
Resolves #757 - add PID into item view (explicitly) and copyable. Adds a row with PID under authors, uses clipboardjs from #764 