### PR TITLE
Resolves #766 - New collection/community with epic PID

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -21,9 +21,13 @@ import org.dspace.core.*;
 import org.dspace.eperson.Group;
 import org.dspace.event.Event;
 import org.dspace.handle.HandleManager;
+import org.dspace.identifier.Handle;
+import org.dspace.identifier.IdentifierException;
+import org.dspace.identifier.IdentifierService;
 import org.dspace.storage.rdbms.DatabaseManager;
 import org.dspace.storage.rdbms.TableRow;
 import org.dspace.storage.rdbms.TableRowIterator;
+import org.dspace.utils.DSpace;
 import org.dspace.workflow.WorkflowItem;
 import org.dspace.xmlworkflow.storedcomponents.CollectionRole;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
@@ -232,11 +236,15 @@ public class Collection extends DSpaceObject
 
         try
         {
-            c.handle = (handle == null) ?
-                       HandleManager.createHandle(context, c) :
-                       HandleManager.createHandle(context, c, handle);
+            IdentifierService identifierService = new DSpace().getSingletonService(IdentifierService.class);
+            if(handle == null) {
+                identifierService.register(context, c);
+            }else{
+                identifierService.register(context, c, handle);
+            }
+            c.handle = identifierService.lookup(context, c, Handle.class);
         }
-        catch(IllegalStateException ie)
+        catch(IllegalStateException | IdentifierException ie)
         {
             //If an IllegalStateException is thrown, then an existing object is already using this handle
             //Remove the collection we just created -- as it is incomplete
@@ -249,7 +257,7 @@ public class Collection extends DSpaceObject
             } catch(Exception e) { }
 
             //pass exception on up the chain
-            throw ie;
+            throw new IllegalStateException(ie);
         }
 
         // create the default authorization policy for collections


### PR DESCRIPTION
Resolves #766 - New collection/community with epic PID. Use ConfigurableHandleIdentifierProvider (through IdentifierService); as a result default community configuration (the one with `community=*`) of `lr.pid.community.configurations` is used. Ie. when your default is to use epic every new collection or community will be registered with epic. The subprefix applies too.