### PR TITLE
New command extendedimport

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/app/itemimport/ItemImport.java
@@ -1,0 +1,54 @@
+package cz.cuni.mff.ufal.dspace.app.itemimport;
+
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+
+/**
+ * Created by okosarko on 24.1.17.
+ */
+public class ItemImport extends org.dspace.app.itemimport.ItemImport {
+
+
+    @Override
+    protected Item addItem(Context c, Collection[] mycollections, String path,
+                        String itemname, PrintWriter mapOut, boolean template) throws Exception{
+        Item item = super.addItem(c, mycollections, path, itemname, mapOut, template);
+        Bitstream[] bits = item.getNonInternalBitstreams();
+        for(Bitstream bit : bits){
+            loadBitstreamMetadata(c, bit, path + File.separatorChar + itemname
+                    + File.separatorChar);
+            bit.update();
+        }
+        c.commit();
+        return item;
+    }
+
+    private void loadBitstreamMetadata(Context c, final Bitstream bit, String path) throws SAXException, AuthorizeException,
+            TransformerException, IOException, SQLException, ParserConfigurationException {
+        FilenameFilter bitstreamMetadataFileFilter = new FilenameFilter()
+        {
+            public boolean accept(File dir, String n)
+            {
+                return n.startsWith(bit.getName() + "_metadata_");
+            }
+        };
+        File folder = new File(path);
+        File[] files = folder.listFiles(bitstreamMetadataFileFilter);
+        for(File file : files){
+            loadDublinCore(c, bit, file.getAbsolutePath());
+        }
+
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -209,6 +209,8 @@ public class ItemImport
 
             options.addOption("h", "help", false, "help");
 
+            options.addOption("x", "extending-class", true, "Class name to use in main. Leave empty if you don't know what it is.");
+
             CommandLine line = parser.parse(options, argv);
 
             String command = null; // add replace remove, etc
@@ -434,7 +436,13 @@ public class ItemImport
                 System.exit(1);
             }
 
-            ItemImport myloader = new ItemImport();
+            ItemImport myloader;
+            if(line.hasOption("x")){
+                String name = line.getOptionValue("x", "org.dspace.app.itemimport.ItemImport");
+                myloader = (ItemImport) Class.forName(name).newInstance();
+            }else{
+                myloader = new ItemImport();
+            }
 
             // create a context
             Context c = new Context();
@@ -883,7 +891,7 @@ public class ItemImport
      * @param itemname handle - non-null means we have a pre-defined handle already
      * @param mapOut - mapfile we're writing
      */
-    private Item addItem(Context c, Collection[] mycollections, String path,
+    protected Item addItem(Context c, Collection[] mycollections, String path,
             String itemname, PrintWriter mapOut, boolean template) throws Exception
     {
         String mapOutputString = null;
@@ -1108,7 +1116,7 @@ public class ItemImport
         }
     }
 
-    private void loadDublinCore(Context c, Item myitem, String filename)
+    protected void loadDublinCore(Context c, DSpaceObject myitem, String filename)
             throws SQLException, IOException, ParserConfigurationException,
             SAXException, TransformerException, AuthorizeException
     {
@@ -1147,7 +1155,7 @@ public class ItemImport
         }
     }
 
-    private void addDCValue(Context c, Item i, String schema, Node n) throws TransformerException, SQLException, AuthorizeException
+    private void addDCValue(Context c, DSpaceObject i, String schema, Node n) throws TransformerException, SQLException, AuthorizeException
     {
         String value = getStringValue(n); //n.getNodeValue();
         // compensate for empty value getting read as "null", which won't display

--- a/dspace/config/launcher.xml
+++ b/dspace/config/launcher.xml
@@ -135,6 +135,14 @@
         </step>
     </command>
     <command>
+        <name>extendedimport</name>
+        <description>Import items with bitstream metadata into DSpace</description>
+        <step>
+            <class>cz.cuni.mff.ufal.dspace.app.itemimport.ItemImport</class>
+            <argument>-xcz.cuni.mff.ufal.dspace.app.itemimport.ItemImport</argument>
+        </step>
+    </command>
+    <command>
         <name>index-authority</name>
         <description>Indexes all metadata fields that use solr authority</description>
         <step>


### PR DESCRIPTION
The simple archive format can now contain "bitstreamName_metadata_*.xml" files in the usual (item metadata) format. * in this case is a schema name

usage:
```
bin/dspace extendedimport -a -e kosarko@ufal.mff.cuni.cz -c 11858/00-097C-0000-0001-4877-A -s /tmp/import -m /tmp/mapfile
```
This will create a new item with two bitstreams and add metadata to that bitstream which is named "moses.ini";

```
$ ls -R /tmp/import/
/tmp/import/:
1

/tmp/import/1:
contents         license.txt  metadata_local.xml  moses.ini_metadata_local.xml
dublin_core.xml  Makefile     moses.ini
```

and `moses.ini_metadata_local.xml`:
```
<?xml version="1.0" encoding="utf-8" standalone="no"?>
<dublin_core schema="local">
  <dcvalue element="bitstream" qualifier="info" language="*">key1|value1</dcvalue>
  <dcvalue element="bitstream" qualifier="info" language="*">key2|value2</dcvalue>
</dublin_core>
```

@vidiecan is this still relevant?