### PR TITLE
Resolves #773 - update currentAsOf

### DIFF
--- a/dspace/config/crosswalks/oai/description-olac.xml
+++ b/dspace/config/crosswalks/oai/description-olac.xml
@@ -1,4 +1,4 @@
-<olac-archive type="institutional" currentAsOf="2015-11-19"
+<olac-archive type="institutional" currentAsOf="${lr.description.currentAsOf}"
          xmlns="http://www.language-archives.org/OLAC/1.1/olac-archive"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.language-archives.org/OLAC/1.1/olac-archive

--- a/utilities/project_helpers/scripts/makefile
+++ b/utilities/project_helpers/scripts/makefile
@@ -177,6 +177,7 @@ compile: deploy_logs
 	@echo "COMPILING SOURCE ..."
 	@echo "Updating lr.compile.time..."
 	@if grep -q "lr\.compile\.time" $(LOCAL_CONF);then sed --follow-symlinks -i'' "s/^lr\.compile\.time=.*/lr.compile.time=`date`/" $(LOCAL_CONF); else echo -e "$(RED)Compile time not updated$(NORMAL)";fi
+	@sed --follow-symlinks -i'' '/lr.description.currentAsOf/d' $(LOCAL_CONF) && echo "lr.description.currentAsOf=`date +%Y-%m-%d`" >> $(LOCAL_CONF)
 	@cd $(DIR_SOURCE) && mvn clean package $(MVN_OPTS) 2>&1 | $(HIDE_PASSW) | tee $(DIR_DEPLOY_LOGS)/$@.log
 	@echo ""
 	@if grep -q "BUILD FAILURE" $(DIR_DEPLOY_LOGS)/compile.log; then \


### PR DESCRIPTION
Resolves #773 - update currentAsOf; use automatically generated lr.description.currentAsOf as lr.compile.time is in different format (and granularity).