### PR TITLE
Resolves #455 - updated TOS to version 1.0

### DIFF
--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/terms-of-service.html
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/terms-of-service.html
@@ -1,9 +1,13 @@
 <div id="faq-like">
 
-	<h2 id="ufal-point-faq">CLARIN Terms of Service (v0.95)</h2>
+	<h2 id="ufal-point-faq">CLARIN Terms of Service (v1.0)</h2>
 
     <hr />
 	<div>
+
+<h3>Preamble</h3>
+
+<p>Welcome to $REPOSITORY_NAME. This repository service is provided to you by $A_CENTRE_OR_UNIT_WITH_LEGAL_PERSONALITY, located at $FULL_ADDRESS, hereinafter referred to as CLARIN Centre. The mission of CLARIN is to provide as wide access as possible to language research materials and tools around Europe. To archive this goal, we set some ground rules in this document. By accessing or using, and in consideration of the CLARIN Services provided to you, you agree to abide by the Terms of Use below, which can be updated or modified according to article 9.</p>
 
 <h3>1. Governing Terms</h3>
 
@@ -72,15 +76,40 @@
     <p>
     The offered content may belong to certain sub-categories:
     <br />
-    A requirement for strictly Non-Commercial use (NC)
-    <br />
-    A requirement to inform the copyright holder regarding the usage of the tools and/or the resources in published articles (INF)
-    <br />
-    A option to redeposit modified versions of the tools and resources with the Service Provider (ReD)
-    <br />
-    A requirement that the resource has to be kept in the CLARIN Secure Server environment (LOC)
-    <br />
-    A requirement that the Resource may need to be handled with care in order to respect the privacy of the personal data it contains and if samples of the data are published, they must be anonymized according to best practices (PD)
+    <ul>
+	<li>Identification and Access conditions
+		<ul>
+			<li>ID: The user needs to be authenticated or identified</li>
+			<li>AFFIL=x: The user needs to be affiliated with some community, e.g. a community of academic researchers (x=EDU) or a community of language research and technology researchers more generally (x=META)</li>
+			<li>PERM: The user can only be given permission to use the resource on a case-by-case basis, such as a mandatory fee or a research plan</li>
+			<li>FF: A fee is required to get access to the resource</li>
+			<li>PLAN: The right holder requires a research plan for granting access</li>
+		</ul>
+	</li>
+	<li>General Use conditions
+		<ul>
+			<li>BY: Attribution, i.e. acknowledgement of authorship, is required</li>
+			<li>NC: The content is available only for non-commercial purposes</li>
+			<li>INF: Informing the rights holder about the use of the resource is required</li>
+			<li>LOC: The content is available only at a single location, center, or site?</li>
+			<li>LRT: The content is available only for language research and technology development</li>
+			<li>PRIV: There are personal data in the resource</li>
+		</ul>
+	</li>
+	<li>Distribution conditions
+		<ul>
+			<li>NORED: The user is not permitted to redistribute the resource</li>
+			<li>DEP: The user is not permitted to redistribute the resource but as an exception to this rule, the user may still distribute modified versions via CLARIN</li>
+			<li>SA: The resource can be redistributed under similar conditions, i.e. is the license reciprocal</li>
+			<li>ND: The user is not permitted to make derivate works, i.e. works containing copyrighted parts of the original</li>
+		</ul>
+	</li>
+	<li>Other conditions
+		<ul>
+			<li>*: 	There are other non-standard conditions in the license that the user should pay attention to</li>
+		</ul>
+	</li>
+	</ul>
     <br />
     The User agrees to adhere to these requirements.
     </p>
@@ -105,7 +134,7 @@
 <h3>6. Governing Law and Entire Agreement</h3>
     
     <p>    
-    These Terms are governed by the laws of Finland without regard to the rules of conflict of law that may cause the laws of another jurisdiction to apply. The User agrees to the sole and exclusive jurisdiction and venue of the Espoo District Court of Law in the event of any dispute of any kind arising from or relating to the CLARIN Services, or the User's use or review of it. However, CLARIN has the right to use the laws of another jurisdiction to get injunctive measures against the misuse of the CLARIN Service.
+    These Terms are governed by the laws of $COUNTRY without regard to the rules of conflict of law that may cause the laws of another jurisdiction to apply. The User agrees to the sole and exclusive jurisdiction and venue of the $CITY District Court of Law in the event of any dispute of any kind arising from or relating to the CLARIN Services, or the User’s use or review of it. However, CLARIN has the right to use the laws of another jurisdiction to get injunctive measures against the misuse of the CLARIN Service.
     </p>    
     
     <p>    

--- a/utilities/adapt_tos.pl
+++ b/utilities/adapt_tos.pl
@@ -1,0 +1,71 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Tie::File;
+
+# define paths for TOS and local.properties
+my $tosfile = '/opt/repository/sources/dspace/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/terms-of-service.html';
+my $locpropfile = '/opt/repository/sources/dspace/local.properties';
+
+my ($repo_name,$centre_legal_entity,$full_address,$country,$city);
+
+# process local.properties to get the needed values
+open (my $lp, '<', $locpropfile);
+
+while (my $in = <$lp>)
+{
+	if ($in =~ /^dspace\.name/)
+	{
+		(undef,$repo_name) = split /=/, $in;
+		chomp $repo_name;
+		$repo_name =~ s/^\s//;
+	}
+	elsif ($in =~ /^lr.description.institution /)
+	{
+		(undef,$centre_legal_entity) = split /=/, $in;
+		chomp $centre_legal_entity;
+		$centre_legal_entity =~ s/^\s//;
+	}
+	elsif ($in =~ /^lr.description.location/)
+	{
+		(undef,$full_address) = split /=/, $in;
+		chomp $full_address;
+		$full_address =~ s/^\s//;
+	}
+	elsif ($in =~ /^lr.description.shortLocation/)
+	{
+		(undef,my $location) = split /=/, $in;
+		chomp $location;
+		($city,$country) = split /,/,  $location;
+		$city =~ s/^\s//;
+		$country =~ s/^\s//;
+	}
+}
+
+# process TOS file to replace variables with values from local.properties
+tie my @tosarray, 'Tie::File', $tosfile or die $!;
+foreach my $line (@tosarray)
+{
+	if ($line =~ /REPOSITORY_NAME/)
+	{
+		$line =~ s/\$REPOSITORY_NAME/$repo_name/;
+	}
+	if ($line =~ /A_CENTRE_OR_UNIT_WITH_LEGAL_PERSONALITY/)
+	{
+		$line =~ s/\$A_CENTRE_OR_UNIT_WITH_LEGAL_PERSONALITY/$centre_legal_entity/;
+	}
+	if ($line =~ /FULL_ADDRESS/)
+	{
+		$line =~ s/\$FULL_ADDRESS/$full_address/;
+	}
+	if ($line =~ /COUNTRY/)
+	{
+		$line =~ s/\$COUNTRY/$country/;
+	}
+	if ($line =~ /CITY/)
+	{
+		$line =~ s/\$CITY/$city/;
+	}
+}
+


### PR DESCRIPTION
As we briefly discussed on Slack and in Budapest, I have taken the TOS version 1.0 from the CLARIN website and updated the version within CLARIN DSpace accordingly (mainly changing the hard coded localities into variables). I also added a small script to utilities that reads in local.properties and fills in the variables in the TOS document from there. This works for our installation, but might not work for everybody depending on how they fill in certain values in local.properties.


PS: I wasn't sure if this was the right branch to work on. If not, please tell me on which branch I should base future work.