### PR TITLE
Fixes #804 - bitstreams of replaced items not hidden

### DIFF
--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/bootstrap/js/ufal.min.js
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/bootstrap/js/ufal.min.js
@@ -69,6 +69,8 @@ jQuery(document)
 
         ufal.browse.handle_date_input();
 
+        ufal.utils.replaced_files();
+
         jQuery("[data-toggle='tooltip']").tooltip();
 
         // I agree button in license agreement should be large
@@ -511,9 +513,23 @@ ufal.utils = {
             }
         }
         return "";    	
+    },
+
+    replaced_files: function () {
+        if (jQuery("#replaced_by_alert").length > 0) {
+            jQuery("#files_section").hide();
+            jQuery("#replaced_by_alert")
+                .append(
+                    '<span class="font_smaller" style="display: inline-block; margin-top: 1em;" id="show_files_info">' + $.i18n._("autocomplete-original-data-help") + '<a href="#show-files" id="show_files_link">' + $.i18n._('autocomplete-here') + '</a>.</span>');
+            jQuery("#show_files_link").on('click', function () {
+                jQuery("#show_files_info").hide();
+                jQuery("#files_section").show();
+                jQuery('html, body').delay(100).animate({
+                    scrollTop: jQuery("#files_section").offset().top
+                }, 200);
+            });
+        }
     }
-    
-    
 }
 
 //

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/js/ufal-submission.js
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/js/ufal-submission.js
@@ -82,23 +82,6 @@ ufal.submissions = {
 
     },
 
-    handle_files: function () {
-        if (jQuery("#replaced_by_alert").length > 0) {
-            jQuery("#files_section").hide();
-            jQuery("#replaced_by_alert")
-                .append(
-                    '<span class="font_smaller" style="display: inline-block; margin-top: 1em;" id="show_files_info">' + $.i18n._("autocomplete-original-data-help") + '<a href="#show-files" id="show_files_link">' + $.i18n._('autocomplete-here') + '</a>.</span>');
-            jQuery("#show_files_link").on('click', function () {
-                jQuery("#show_files_info").hide();
-                jQuery("#files_section").show();
-                jQuery('html, body').delay(100).animate({
-                    scrollTop: jQuery("#files_section").offset().top
-                }, 200);
-            });
-        }
-    },
-
-
     autocomplete_solr: function (obj, url, updater_function) {
         ufal.submissions.configurable_autocomplete_solr(
             obj,
@@ -447,5 +430,4 @@ jQuery(document).ready(function () {
     ufal.submissions.fix_l10n();
     ufal.submissions.handle_submission_js();
     ufal.submissions.autocomplete();
-    ufal.submissions.handle_files();
 }); // ready


### PR DESCRIPTION
Fixes #804 - bitstreams of replaced items not hidden. There were things marked as belonging to submission that in fact belong to item-view (thus should have stayed in ufal.min.js). PR against clarin as this is a hotfix and release will follow