### PR TITLE
Resolves #807 - Custom messages for withdrawn items

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowItemUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowItemUtils.java
@@ -409,6 +409,12 @@ public class FlowItemUtils
 		}
 		if(!StringUtils.isEmpty(reason)){
 			item.store_provenance_info(String.format("The item was withdrawn with the following reason: \"%s\"", reason), context.getCurrentUser());
+			Metadatum md = new Metadatum();
+			md.schema = "local";
+			md.element = "withdrawn";
+			md.qualifier = "reason";
+			md.value = reason;
+			item.addMetadatum(md);
 		}
 		item.withdraw();
 		context.commit();

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -353,7 +353,9 @@
     <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_claimed"><h4>This item is managed by another repository</h4></message>
     <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_claimed">You will find this item at the following location(s):</message>
     <message key="xmlui.ArtifactBrowser.RestrictedItem.para2_item_claimed">The author(s) asked us to hide this submission. <strong>We still keep all the data and metadata of the original submission</strong> but the submission is now located at the above url(s). If you need the contents of the original submission, contact us at our <a class="helpdesk-tolink">Help Desk</a>.</message>
-    
+
+    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_reason">The reason for withdrawal:</message>
+
     <message key="xmlui.administrative.item.ConfirmItemForm.withdraw_para_extraInfo">You may wish to provide some extra information; a handle in case the item was moved someplace else and/or reason for the removal.</message>
     <message key="xmlui.administrative.item.ConfirmItemForm.withdraw_help_extra_handle">If you fill this, users wanting to view the item will get special message. With a link created from the new PID.</message>
     <message key="xmlui.administrative.item.ConfirmItemForm.withdraw_label_extra_handle">The new PID:</message>
@@ -369,7 +371,7 @@
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">unknown</message>
         <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Proceed to login screen</message>
 
-        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">This item is withdrawn</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn"><h4>This item is withdrawn</h4></message>
         <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">The selected item is withdrawn and is no longer available.</message>
         <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">The selected item is access restricted and requires credentials to view. Please login to access the item.</message>
         <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Your user account does not have the credentials to view this item. Please contact the <a class="helpdesk-tolink">Help Desk</a> if you have any questions.</message>

--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -111,6 +111,12 @@
         <qualifier>redirectToURL</qualifier>
         <scope_note>Get the bitstream from this URL.</scope_note>
     </dc-type>
+    <dc-type>
+        <schema>local</schema>
+        <element>withdrawn</element>
+        <qualifier>reason</qualifier>
+        <scope_note>Store the withdrawal reason in addition to provenance</scope_note>
+    </dc-type>
 </dspace-dc-types>
 
 

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -368,6 +368,8 @@
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_claimed">Tento záznam najdete na následujících místech:</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para2_item_claimed">Autoři tohoto záznamu nás požádali o jeho skrytí. <strong>Stále máme všechna data i metadata původního záznamu.</strong> K záznamu by mělo být přistupováno výhradně přes výše uvedené url. Pokud z nějakého důvodu potřebujete původní záznam, kontaktujte naši <a class="helpdesk-tolink">poradnu</a>.</message>
 
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_reason">Důvod odstranění:</message>
+
 	<message key="xmlui.administrative.item.ConfirmItemForm.withdraw_para_extraInfo">Můžete vyplnit informace navíc. Handle, pokud byl záznam přesunut jinam a/nebo důvod pro odstranění.</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.withdraw_help_extra_handle">Pokud toto vyplníte uživatel zobrazující tento záznam uvidí zprávu s odkazem na nové PID.</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.withdraw_label_extra_handle">Nové PID:</message>
@@ -383,7 +385,7 @@
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">neznámý</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.login">Pokračujte na přihlašovací obrazovku.</message>
 	
-        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Tento záznam byl vyřazen</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn"><h4>Tento záznam byl vyřazen</h4></message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Vybraný záznam byl vyřazen a není nadále dostupný.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">Vybraný záznam je záznam s omezeným přístupem a pro jeho zobrazení musíte mít potřebná oprávnění. Prosím, pro zobrazení tohoto záznamu se přihlaste.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Váš účet nemá potřebná oprávnění pro zobrazení tohoto záznamu. Jestli máte jakékoliv nejasnosti, obraťte se na <a class="helpdesk-tolink">poradnu</a>.</message>


### PR DESCRIPTION
Resolves #807 - Custom messages for withdrawn items

Add new field for reason of withdrawal
Display on tombstone page if not replacedby (that has a predefined messages).
Don't forget to run `make update_metadata_scheme` (and restart)