### PR TITLE
Fixes #797 - As non admin curator, you must sign custom licenses in order to approve an item

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/InstallItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItem.java
@@ -248,9 +248,11 @@ public class InstallItem
                 try {
                     DSpaceApi.authorizeBitstream(context, b);
                 }catch (AuthorizeException e){
+                    c.turnOffAuthorisationSystem();
                     //Anonymous user not allowed by license - don't generate preview
                     b.clearMetadata(ProcessBitstreams.schema, ProcessBitstreams.element, ProcessBitstreams.qualifier, Item.ANY);
                     b.update();
+                    c.restoreAuthSystemState();
                 }
             }
         }


### PR DESCRIPTION
Fixes #797 - As non admin curator, you must sign custom licenses in order to approve an item

For #702 we've modified InstallItem in a way that worked only for admins
