### PR TITLE
resolves #826 - I see (ÃšFAL) in the emails

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/health/VLOCheck.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/health/VLOCheck.java
@@ -9,6 +9,7 @@
  */
 package cz.cuni.mff.ufal.health;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -45,7 +46,8 @@ public class VLOCheck extends Check {
                 return "PLEASE configure lr.harvester.info.url";
             }
             String dspace_name = ConfigurationManager.getProperty("dspace.name");
-            dspace_name = dspace_name.replaceAll("[ ,/-]+","_");
+            dspace_name = dspace_name.replaceAll("[() ,/-]+","_");
+            dspace_name = StringUtils.stripAccents(dspace_name);
             harvesterInfoUrl = harvesterInfoUrl.endsWith("/") ? harvesterInfoUrl + dspace_name :
                     harvesterInfoUrl + "/" + dspace_name;
             harvesterInfoUrl = harvesterInfoUrl + ".html";

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -85,7 +85,11 @@ Common usage:
     </loadproperties>
 
     <!-- Load the configuration -->
-    <property file="${config}" />
+    <loadproperties encoding="UTF-8" srcFile="${config}">
+        <filterchain>
+            <escapeunicode/>
+        </filterchain>
+    </loadproperties>
 
     <!-- Timestamp date used when creating backup directories -->
     <tstamp>


### PR DESCRIPTION
resolves #826 - I see (ÃšFAL) in the emails.

ant interpolation of email templates now should use "utf-8" values.
vlocheck now scrubs `dspace.name` more carefully