### PR TITLE
Resolves #841 - Limit archive previews to reasonable size

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ProcessBitstreams.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ProcessBitstreams.java
@@ -104,12 +104,17 @@ public class ProcessBitstreams extends AbstractCurationTask implements Consumer 
         }
 
         DSpaceObject subject = event.getSubject(ctx);
-        DSpaceObject object = event.getObject(ctx);
         int et = event.getEventType();
         Bitstream b = (Bitstream)subject;
 
         if (null != subject) {
-            if (Event.ADD == et || Event.CREATE == et) {
+            boolean original = false;
+            for(Bundle bundle : b.getBundles()){
+                if("ORIGINAL".equals(bundle.getName())){
+                    original = true;
+                }
+            }
+            if (original && (Event.ADD == et || Event.CREATE == et)) {
                 processBitstream(b);
             } else if (Event.DELETE == et || Event.REMOVE == et) {
                 // automatically removed

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ProcessBitstreams.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ProcessBitstreams.java
@@ -190,11 +190,17 @@ public class ProcessBitstreams extends AbstractCurationTask implements Consumer 
             if(is instanceof ArchiveInputStream) {
             	ArchiveInputStream ais = (ArchiveInputStream)is;
 	            ArchiveEntry entry;
+	            int i = 0;
 	            while ((entry = ais.getNextEntry()) != null) {
 	                String content = String.format(
 	                    "%s|%d", entry.getName(), entry.getSize()
 	                );
 	                b.addMetadata( schema, element, qualifier, Item.ANY, content );
+	                //don't add more than 1000 files
+	                if(++i >= 1000){
+	                    b.addMetadata(schema, element, qualifier, Item.ANY, "...");
+	                    break;
+                    }
 	            }
             } else {
             	InputStreamReader r = new InputStreamReader(is);


### PR DESCRIPTION
Resolves #841 - Limit archive previews to reasonable size. Stops adding the preview metadata after reaching 1000th file, after that it just adds on `...` record with size 0.
This PR also add support for some other compress/archive formats.
Restructured the code to always cleanup all the preview metadata on bitstreams.