### PR TITLE
Resolves #799 - Inspect range queries - 206 status code

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/IOUtils.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/IOUtils.java
@@ -20,7 +20,10 @@ import java.util.regex.Pattern;
 
 import org.apache.log4j.Logger;
 
+import javax.servlet.http.HttpServletRequest;
 import java.text.SimpleDateFormat;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class IOUtils {
 
@@ -197,6 +200,32 @@ public class IOUtils {
         }
         return message;
 	}	
-	
+
+	public static boolean requestRangeContainsStart(HttpServletRequest request){
+	    String rangeHeader = request.getHeader("range");
+	    try {
+			if (isNotBlank(rangeHeader)) {
+				String[] parts = rangeHeader.split("=", 2);
+				String unit = parts[0];
+				String ranges = parts[1].replaceAll(" ", "");
+				for (String range : ranges.split(",")) {
+					String[] rangeParts = range.split("-");
+					String start = rangeParts[0];
+					if ("0".equals(start.trim())) {
+						log.debug("Found zero in range header.");
+						return true;
+					}
+				}
+			} else {
+				// No range header -> always stream from start
+				return true;
+			}
+		}catch (Exception e){
+	    	// issue with parsing the header, assume we stream from beginning
+			return true;
+		}
+		log.debug("No zero in range header.");
+		return false;
+	}
 }
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/CurrentActivityAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/CurrentActivityAction.java
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpSession;
 
+import cz.cuni.mff.ufal.dspace.IOUtils;
 import org.apache.avalon.framework.parameters.Parameters;
 import org.apache.cocoon.acting.AbstractAction;
 import org.apache.cocoon.environment.ObjectModelHelper;
@@ -148,7 +149,9 @@ public class CurrentActivityAction extends AbstractAction
 							bitAccessEvents = new LinkedList<>();
 							bitAccessCounter.put(event.getURL(), bitAccessEvents);
 						}
-						bitAccessEvents.add(event);
+						if(IOUtils.requestRangeContainsStart(request)) {
+							bitAccessEvents.add(event);
+						}
 						if (bitAccessEvents.size() > limit) {
 							//yell as this bitstream was accessed more than LIMIT times in the last 10 mins.
 							if(noRecentEmail(event.getURL(), old)) {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import cz.cuni.mff.ufal.UFALLicenceAgreement;
 
+import cz.cuni.mff.ufal.dspace.IOUtils;
 import org.apache.avalon.excalibur.pool.Recyclable;
 import org.apache.avalon.framework.parameters.Parameters;
 import org.apache.cocoon.ProcessingException;
@@ -720,7 +721,8 @@ public class BitstreamReader extends AbstractReader implements Recyclable
             }
         }
 
-        if(item!=null) { // item = null means special bitstream possibly a community logo
+        if(item!=null && IOUtils.requestRangeContainsStart(request)) { // item = null means special bitstream possibly a
+            // community logo
         	// Log download statistics
         	DSpaceApi.updateFileDownloadStatistics(userID, bitstreamID);
         }


### PR DESCRIPTION
Resolves #799 - Inspect range queries - 206 status code.

Update download statistics only if the response would contain the beginning of the file, ie. where range header specified, check if it contains 0. If the header is not specified count as usual.

In BitstreamReader.setup wraps the DSpaceApi.updateFileDownloadStatistics call. In CurrentActivityAction wraps the event addition.