### PR TITLE
Resolves #837 - Error in connecting to the VLO due to name mismatch

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/health/VLOCheck.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/health/VLOCheck.java
@@ -46,7 +46,7 @@ public class VLOCheck extends Check {
                 return "PLEASE configure lr.harvester.info.url";
             }
             String dspace_name = ConfigurationManager.getProperty("dspace.name");
-            dspace_name = dspace_name.replaceAll("[() ,/-]+","_");
+            dspace_name = dspace_name.replaceAll("[() ,/.\"-]+","_");
             dspace_name = StringUtils.stripAccents(dspace_name);
             harvesterInfoUrl = harvesterInfoUrl.endsWith("/") ? harvesterInfoUrl + dspace_name :
                     harvesterInfoUrl + "/" + dspace_name;


### PR DESCRIPTION
Resolves #837 - Error in connecting to the VLO due to name mismatch

added more characters to the "escape list"