### PR TITLE
Resolve #864 - Disable related items in item-view

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -175,10 +175,11 @@
                 </property>
             </bean>
         </property>
+        <!--
         <property name="moreLikeThisConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoveryMoreLikeThisConfiguration">
-                <!--When altering this list also alter the "xmlui.Discovery.RelatedItems.help" key as it describes
-                the metadata fields below-->
+                <!- -When altering this list also alter the "xmlui.Discovery.RelatedItems.help" key as it describes
+                the metadata fields below- ->
                 <property name="similarityMetadataFields">
                     <list>
                         <value>dc.title</value>
@@ -187,14 +188,16 @@
                         <value>dc.subject</value>
                     </list>
                 </property>
-                <!--The minimum number of matching terms across the metadata fields above before an item is found as related -->
+                <!- -The minimum number of matching terms across the metadata fields above before an item is found as
+                 related - ->
                 <property name="minTermFrequency" value="5"/>
-                <!--The maximum number of related items displayed-->
+                <!- -The maximum number of related items displayed- ->
                 <property name="max" value="3"/>
-                <!--The minimum word length below which words will be ignored-->
+                <!- -The minimum word length below which words will be ignored- ->
                 <property name="minWordLength" value="5"/>
             </bean>
         </property>
+        -->
         <!-- When true a "did you mean" example will be displayed, value can be true or false -->
         <property name="spellCheckEnabled" value="true"/>
     </bean>


### PR DESCRIPTION
Resolve #864 - Disable related items in item-view. Commenting out the relevant part in `discovery.xml` disables the feature.