### PR TITLE
Resolves #868 - Login fails

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/Navigation.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/Navigation.java
@@ -135,11 +135,7 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
             return HashUtil.hash(key.toString());
         }
 
-        if(context.getCurrentUser().getEmail() != null) {
-            return HashUtil.hash(context.getCurrentUser().getEmail());
-        }else{
-            return HashUtil.hash(context.getCurrentUser().getNetid());
-        }
+        return HashUtil.hash(context.getCurrentUser().getEmail());
     }
 	
     /**

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/Navigation.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/Navigation.java
@@ -135,7 +135,11 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
             return HashUtil.hash(key.toString());
         }
 
-        return HashUtil.hash(context.getCurrentUser().getEmail());
+        if(context.getCurrentUser().getEmail() != null) {
+            return HashUtil.hash(context.getCurrentUser().getEmail());
+        }else{
+            return HashUtil.hash(context.getCurrentUser().getNetid());
+        }
     }
 	
     /**

--- a/dspace-xmlui/src/main/resources/aspects/EPerson/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/EPerson/sitemap.xmap
@@ -339,7 +339,8 @@ registration, forgotten passwords, editing profiles, and changing passwords.
                 </map:match>
             
                 <map:match pattern="set-email/finished">
-                    <map:transform type="RegistrationFinished"/>
+                    <!-- map:transform type="RegistrationFinished"/ -->
+                    <map:transform type="WelcomeLogin"/>
                 </map:match>
             
                 <!-- Exception states -->


### PR DESCRIPTION
Resolves #868 - Login fails.
Even though a correct redirect (to /set-email) was issued in the described case, it was being overridden because of `resumeInterruptedRequest` and subsequently by `resumeRequest` in `doFilter` of [DSpaceCocoonServletFilter](https://github.com/ufal/clarin-dspace/blob/clarin/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceCocoonServletFilter.java#L235)