### PR TITLE
the default footer path is now absolute

### DIFF
--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/lindat/footer.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/lindat/footer.xsl
@@ -36,6 +36,7 @@
 
       <xsl:variable name="currentLocale" select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='page'][@qualifier='currentLocale']"/>
       <xsl:variable name="localizedDiskPath" select="concat($theme-path-on-disk,'/lib/lindat/',$currentLocale,'/footer.htm')" />
+      <xsl:variable name="defaultDiskPath" select="concat($theme-path-on-disk,'/lib/lindat/','/footer.htm')" />
       <xsl:variable name="path" select="file:new($localizedDiskPath)"/>
       <xsl:variable name="collection"
                     select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='container']"/>
@@ -44,7 +45,7 @@
               <xsl:copy-of select="psu:readFooter($localizedDiskPath, $collection)" />
           </xsl:when>
           <xsl:otherwise>
-              <xsl:copy-of select="psu:readFooter('../../lindat/footer.htm', $collection)" />
+              <xsl:copy-of select="psu:readFooter($defaultDiskPath, $collection)" />
           </xsl:otherwise>
       </xsl:choose>
     </xsl:template>


### PR DESCRIPTION
if the localized footer does not exist, the default should be loaded, but was not found. Might have been caused in b66c1d6 when changing `document()` for `psu:readFooter()`