### PR TITLE
org.dspace.app.util.MetadataExposure @ Bad format in hidden metadata directive

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/MetadataExposure.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/MetadataExposure.java
@@ -229,27 +229,28 @@ public class MetadataExposure
                         hiddenElementSets.get(segment[0]).add(segment[1]);
                     }
                     
-                    if(value != null && !value.equals("") && !"true".equals(value)){
-                    	//select schema
-                    	Map<String, Map<String,String>> elements = hiddenConditions.get(segment[0]);
-                    	if(elements == null){
-                    		elements = new HashMap<String, Map<String,String>>();
-                    		hiddenConditions.put(segment[0], elements);
-                    	}
-                    	//select element
-                    	Map<String,String> qualifiers = elements.get(segment[1]);
-                    	if(qualifiers == null){
-                    		qualifiers = new HashMap<String,String>();
-                    		elements.put(segment[1], qualifiers);
-                    	}
-                    	qualifiers.put(qualifier, value);
-                    }
-
                     // oops..
                     else
                     {
                         log.warn("Bad format in hidden metadata directive, field=\""+mdField+"\", config property="+key);
                     }
+
+                    if(value != null && !value.equals("") && !"true".equals(value)){
+                        //select schema
+                        Map<String, Map<String,String>> elements = hiddenConditions.get(segment[0]);
+                        if(elements == null){
+                            elements = new HashMap<String, Map<String,String>>();
+                            hiddenConditions.put(segment[0], elements);
+                        }
+                        //select element
+                        Map<String,String> qualifiers = elements.get(segment[1]);
+                        if(qualifiers == null){
+                            qualifiers = new HashMap<String,String>();
+                            elements.put(segment[1], qualifiers);
+                        }
+                        qualifiers.put(qualifier, value);
+                    }
+
                 }
             }
         }


### PR DESCRIPTION
```
org.dspace.app.util.MetadataExposure @ Bad format in hidden metadata directive, field="dc.description.provenance", config property=metadata.hide.dc.description.provenance
```
The else belongs to the previous if, moved the lindat addition under the else statement