### PR TITLE
Fixed the path to messages.js

### DIFF
--- a/dspace-xmlui/src/main/webapp/exception2html.xslt
+++ b/dspace-xmlui/src/main/webapp/exception2html.xslt
@@ -18,7 +18,6 @@
     xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
     xmlns:xhtml="http://www.w3.org/1999/xhtml"
     xmlns:mods="http://www.loc.gov/mods/v3"
-    xmlns:file="java.io.File"
     xmlns:dc="http://purl.org/dc/elements/1.1/"
 	xmlns:confman="org.dspace.core.ConfigurationManager"
     xmlns="http://www.w3.org/1999/xhtml"
@@ -259,21 +258,8 @@
 	        <script type="text/javascript" src="{$contextPath}/themes/UFAL/lib/js/jquery-ui.js">&#160;</script>
                 <script type="text/javascript" src="{$contextPath}/themes/UFAL/lib/js/jquery.i18n.js">&#160;</script>
 		<script type="text/javascript">
-		    <xsl:variable name="currentLocale">
-                        <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='page'][@qualifier='currentLocale']"/>
-                    </xsl:variable>
                     <xsl:attribute name="src">
-                        <xsl:variable name="localizedContextPath" select="concat($theme-path,'/lib/js/messages/messages_',$currentLocale,'.js')" />
-                        <xsl:variable name="localizedDiskPath" select="concat($theme-path-on-disk,'/lib/js/messages/messages_',$currentLocale,'.js')" />
-                        <xsl:variable name="path" select="file:new($localizedDiskPath)"/>
-                        <xsl:choose>
-                            <xsl:when test="file:isFile($path)">
-                                <xsl:value-of select="$localizedContextPath" />
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:value-of select="concat($theme-path,'/lib/js/messages/messages.js')" />
-                            </xsl:otherwise>
-                        </xsl:choose>
+                        <xsl:value-of select="concat($contextPath,$theme-path,'/lib/js/messages/messages.js')" />
                     </xsl:attribute>&#160;</script>
 
             <script type="text/javascript" src="{concat($aaiURL, '/discojuice/discojuice-2.1.en.min.js')}">&#160;</script>


### PR DESCRIPTION
The variables and "environment" in exception2html is bit different from rest of the theme's stylesheets. There is no locale.

Resolves ufal/DSpace#900