### PR TITLE
Updating help pages

### DIFF
--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/about.html
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/about.html
@@ -105,8 +105,8 @@ Should anyone have a suspicion that any of the datasets or tools in our reposito
 			University.
 		</p>
 		<p>
-			In order to stay a reliable and trustworthy repository, we undergo periodical assessments by CLARIN and
-			CTS/DSA.
+			In order to stay a reliable and trustworthy repository, we undergo periodical assessments by CLARIN ERIC and
+			<a href="https://www.coretrustseal.org/wp-content/uploads/2019/08/LINDAT-CLARIN.pdf">CTS</a> (formerly DSA).
 		</p>
 		<p>
 			To fulfill the commitments, the repository ensures that datasets are ingested and distributed in
@@ -127,8 +127,9 @@ Should anyone have a suspicion that any of the datasets or tools in our reposito
         <p>
 			We view data and tools as primary research outputs, each submission receives a Persistent IDentifier for reference and
 			the users are <a href="cite">guided to</a> use them. Changes in a dataset after it has been published are
-			not permitted, new submission is required instead. The old a new submissions are linked through their
-			metadata (see <a href="faq">faq</a> for more details).
+			not permitted, new submission is required instead. The old and new submissions are linked through their
+			metadata (see <a href="https://github.com/ufal/clarin-dspace/wiki/New-Version-Guide">new version
+			guide</a> 	for more details).
 		</p>
 		<p>
 			Through regular participation in CLARIN activities, Open Repositories and various other meetings, schools

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/cs/about.html
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/cs/about.html
@@ -97,8 +97,62 @@ Pokud by někdo měl podezření, že některý z datových souborů nebo někte
     <div>
 		<h3 id="preservation-policy">Pravidla pro uchovávání dat</h3>
 		<p>
-        LINDAT/CLARIN se zavázal k dlouhodobé péči o data a nástroje uložené v repozitáři a snaží se používat nejlepší stávající osvědčené postupy v oblasti uchovávání digitálních záznamů. Disponujeme <a href="https://assessment.datasealofapproval.org/">"Datovou pečetí"</a>, která zajišťuje, že námi archivovaná data budou i v budoucnu k dispozici. Disponujeme také pravidelně obnovovanou certifikací Clarin ERIC, která potvrzuje, že používáme kompatibilní standardy, repozitář má vysokou dostupnost, je zajištěna ochrana práv duševního vlastnictví a osobních údajů a že poskytování služeb je na úrovni předepsané Clarin ERIC.
-        </p>
+        LINDAT/CLARIN se zavázal k dlouhodobé péči o data a nástroje uložené v repozitáři a snaží se používat
+			nejlepší stávající osvědčené postupy v oblasti uchovávání digitálních záznamů, jak je stanovuje CLARIN,
+			OAIS a/nebo Univerzita Karlova. Viz	<a href="#mission-statement">Naše poslání</a>.
+		</p>
+        <p>
+		Abychom zůstali spolehlivým a důvěryhodným úložištěm, podstupujeme pravidelná hodnocení ze strany CLARIN ERIC a
+		<a href="https://www.coretrustseal.org/wp-content/uploads/2019/08/LINDAT-CLARIN.pdf">CTS</a> (dříve DSA).
+		</p>
+		<p>
+			Abychom mohli plnit naše závazky, repozitář zajišťuje, že přijatá data mají licenci a pod touto licencí
+			je dále poskytuje (viz <a href="#about-contracts">Licenční ujednání a smlouvy</a>). Někdy
+			(u licencí, které nepovolují volný přístup) to znamená, že k datům mají přístup pouze oprávnění
+			uživatelé.
+		</p>
+        <p>
+			Proces nahrání dat popsaný v <a href="deposit">Jak ukládat vaše data</a> a práce našich editorů
+			zajišťuje, že data budou k nalezení prostřednictvím našeho vyhledávače,
+			externě přes OAI-PMH a v různých dalších vyhledávačích. Proto vyžadujeme detailní  <a href="#metadata-policy">metadata</a>.
+			Metadata jsou volně přístupná.
+		</p>
+        <p>
+			Integritu přijatých dat a úplnost metadat ověřuje řada automatizovaných procedur. Na úrovni systému
+			používáme různé zálohovací strategie (včetně zálohování do jiné lokality) a hardware monitorujeme. Data
+			jsou dostupná online.
+		</p>
+        <p>
+			Data i nástroje vnímáme jako hlavní výstupy výzkumu. Ke každému záznamu v repozitáři je přidělen
+			perzistentní identifikátor, který slouží jako trvalý odkaz. Uživatelé jsou <a href="cite">vedeni k
+			jejich používaní</a>.
+			Jednou zveřejněná data není možné měnit, vždy je potřeba vytvořit nový záznam. Oba záznamy (starý a nový)
+			jsou provázány odkazy (PID) v metadatech (viz <a href="https://github.com/ufal/clarin-dspace/wiki/New-Version-Guide">nová verze</a>).
+		</p>
+        <p>
+				 Pracovníci repozitáře se pravidelně účastní aktivit v rámci CLARIN, konference Open Repositories a
+			různých dalších konferencí, setkání a tréninků. Udržují si tak přehled o nových technologiích a
+			iniciativách.
+		</p>
+        <p>
+			Námi používaný systém (DSpace) nabízí různé možnosti exportu, což zajistí, že v případě potřeby bude
+			data i metadata možné přesunout do jiného systému.
+		</p>
+		<p>
+            Nahraná data by ideálně měla být v jednom z formátů, které doporučuje CLARIN, pokud to není možné, jsou
+			hlavní zásady výběru formátu následující:
+			Otevřené standardy jsou preferovány před proprietárními, formáty by měly být dobře zdokumentovány, ověřitelné a ověřené praxí.
+			Pokud je to možné, upřednostňují se textové formáty před binárními a v případě digitalizace analogového
+			signálu se doporučuje bezeztrátová nebo žádná komprese.
+			Preferované formáty se budou časem měnit, v takovém případě vynaloží repozitář veškeré úsilí k převodu
+			dat na nový formát. Originály budou pro účely reprodukovatelnosti zachovány beze změn (tj. pro nový
+			formát bude vytvořen nový záznam, který propojíme se starým).
+		</p>
+        <p>
+			V případě ukončení financování bude obsah repozitáře převeden na jiné CLARIN centrum. Zatímco se bude
+			jednat o detailech tohoto přesunu (právní aspekty apod.), nabízí ÚFAL (jakožto hostitelská instituce)
+			časový rámec 10 let, během kterých zajistí přístup k datům.
+		</p>
 	</div>
 	<br/>
 

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/cs/deposit.html
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/cs/deposit.html
@@ -21,7 +21,12 @@
                 v dialogovém okně 'Přihlásit se' -  'Seznam organizací', pak se zaregistrujte na <a href="https://user.clarin.eu/user/register">clarin.eu</a>
                 a za pomoci "clarin.eu website account" se autentizujte (nalogujte). Pokud nemůžete použít žádnou z uvedených autentizačních metod  nebo pokud narazíte na problém, neváhejte nás kontaktovat na 
                <a class="helpdesk-tolink" href="#">Lince podpory</a> a my pro vás vytvoříme místní účet.</div>
-        <div id="step1" style="margin-bottom: 20px;">
+    <div>
+        Návod níže popisuje přidání nového záznamu, pokud nahráváte novou verzi záznamu dostupného v repozitáři, jsou
+        k dispozici
+        <a href="https://github.com/ufal/clarin-dspace/wiki/New-Version-Guide">detailnější instrukce</a>.
+    </div>
+    <div id="step1" style="margin-bottom: 20px;">
                 <h3>Krok 1: Přihlášení</h3>
                 <p style="margin-top: 10px; margin-bottom: 10px;">Chcete-li zahájit vložení nové datové položky, musíte se nejprve přihlásit. Klikněte na 'Přihlásit se' pod 'Můj účet' v menu na pravé straně.</p>
                 <figure class="print_screen_figure">

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/cs/faq.html
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/cs/faq.html
@@ -22,6 +22,8 @@
 		<li><a href="#list-of-licenses">Kde najdu více informací o podporovaných licencích?</a></li>
 		<li><a href="#real-authors">Proč upřednostňujeme skutečné autory před institucemi?</a></li>
 		<li><a href="#searching">Jak získám co nejvíce vyhledávek?</a></li>
+		<li><a href="#new-version">Jak vytvořím novou verzi záznamu?</a></li>
+		<li><a href="#new-version">Jak upravím nahraná data?</a></li>
 	</ul>
     <hr />
 
@@ -206,6 +208,12 @@ Kontakt na "institucionální" Linku podpory pro vaše data je skvělý, ale zá
 			<dt><a href="../discover?query=author%3A%28Bojar+%26%26+-Tamchyna%29+%26%26+%28dc.language.iso%3A%28ces+AND+eng%29+OR+language%3A%28czech+AND+english%29%29">autor:(Bojar &amp;&amp; -Tamchyna) &amp;&amp; (dc.language.iso:(ces AND eng) OR language:(czech AND english))</a></dt>
 			<dd>Hledejte položky od jednoho autora a ne od jiného; zajímavé jsou jen ty položky, které jsou v českém a zároveň anglickém jazyce (např. paralelní korpus).</dd>
 		</dl>
+		</p>
+	</div>
+	<div>
+		<h3 id="new-version">Nová verze/změny v datech</h3>
+		<p>Jak se můžete dočíst v jiných částech nápovědy k repozitáři, neumožňujeme měnit zveřejněná data. Je
+			potřeba vytvořit <a href="https://github.com/ufal/clarin-dspace/wiki/New-Version-Guide">nový záznam (verzi)</a>.
 		</p>
 	</div>
 </div>

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/cs/item-lifecycle.html
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/cs/item-lifecycle.html
@@ -45,7 +45,9 @@ Publikované příspěvky jsou k dispozici v našem vyhledávacím rozhraní, v 
       </p>
       
       <p>Přes naši <strong>Linku podpory</strong> umožňujeme provést drobné změny v příspěvcích (např. opravu překlepů v dokumentaci). I zde záleží na konkrétním případu a rozsahu změny.
-     Pokud jde o větší změny, vkladatel příspěvku je obvykle vyzván, aby předložil novou verzi příspěvku. Zároveň zařídíme, aby z metadat původní položky vedl odkaz na novou verzi, a původní položka bude pak označena jako "zastaralá".
+     Pokud jde o větší změny, vkladatel příspěvku je obvykle vyzván, aby předložil
+          <a href="https://github.com/ufal/clarin-dspace/wiki/New-Version-Guide">novou verzi</a>
+          příspěvku. Zároveň zařídíme, aby z metadat původní položky vedl odkaz na novou verzi, a původní položka bude pak označena jako "zastaralá".
        
       </p>
     </div>

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/deposit.html
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/deposit.html
@@ -21,8 +21,14 @@
                 Login dialog list of organisations then register at <a href="https://user.clarin.eu/user/register">clarin.eu</a>
                 and authenticate using "clarin.eu website account". In case you cannot use any authentication method above or
                 if you encounter a problem, do not hesitate to
-                contact our <a class="helpdesk-tolink" href="#">Help Desk</a> and we can create a local account for you.</div>
-        <div id="step1" style="margin-bottom: 20px;">
+                contact our <a class="helpdesk-tolink" href="#">Help Desk</a> and we can create a local account for you.
+        </div>
+        <div>
+            The guide below describes new submissions, if what you plan to submit is a new version of a resource
+            already available in the repository see the
+            <a href="https://github.com/ufal/clarin-dspace/wiki/New-Version-Guide">new version guide</a>.
+        </div>
+    <div id="step1" style="margin-bottom: 20px;">
                 <h3>Step 1: Login</h3>
                 <p style="margin-top: 10px; margin-bottom: 10px;">To start a new submission you have to login first. Click Login under My Account in the right menu panel.</p>
                 <figure class="print_screen_figure">

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/faq.html
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/faq.html
@@ -21,6 +21,8 @@
 		<li><a href="#list-of-licenses">Where can I find more information about supported licenses?</a></li>
 		<li><a href="#real-authors">Why we strongly prefer real authors to institutions?</a></li>
 		<li><a href="#searching">How do I get the most of my searches?</a></li>
+		<li><a href="#new-version">How do I create a new version of a record?</a></li>
+		<li><a href="#new-version">How do I update the submitted data?</a></li>
 	</ul>
     <hr />
 
@@ -249,6 +251,12 @@
 			<dt><a href="../discover?query=author%3A%28Bojar+%26%26+-Tamchyna%29+%26%26+%28dc.language.iso%3A%28ces+AND+eng%29+OR+language%3A%28czech+AND+english%29%29">author:(Bojar &amp;&amp; -Tamchyna) &amp;&amp; (dc.language.iso:(ces AND eng) OR language:(czech AND english))</a></dt>
 			<dd>Search for items by one author and not the other; interesting are only items about both czech and english languages.</dd>
 		</dl>
+		</p>
+	</div>
+	<div>
+		<h3 id="new-version">New versions/updating submitted data</h3>
+		<p>As you may have read elsewhere in the repository help, we do not allow changes in the data after a
+			submission was published. You need to create a new one by <a href="https://github.com/ufal/clarin-dspace/wiki/New-Version-Guide">creating a new version</a>.
 		</p>
 	</div>
 </div>

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/item-lifecycle.html
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/html/item-lifecycle.html
@@ -58,8 +58,9 @@
       </p>
       
       <p>We allow for minor edits of the submission (e.g., typos) through our <strong>Help Desk</strong>. These are also
-      evaluated on case-by-case basis. For major changes, the user is requested to submit a new version of that item
-      and we will indicate in the metadata that it is replaced by a newer version. 
+          evaluated on case-by-case basis. For major changes, the user is requested to submit a
+          <a href="https://github.com/ufal/clarin-dspace/wiki/New-Version-Guide">new version</a>
+          of that item and we will indicate in the metadata that it is replaced by a newer version.
       </p>
     </div>
 


### PR DESCRIPTION
The about pages (english and czech) have been synchronized and updated with CTS link. The logo is part of the lindat-common footer.

The faq, deposit and lifecycle pages now link to new version guide. This resolves #780 