### PR TITLE
Fixes #851 - Preview contains strange files ... and other glitches

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/FileTreeViewGenerator.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/FileTreeViewGenerator.java
@@ -1,6 +1,7 @@
 package cz.cuni.mff.ufal;
 
 import java.util.Hashtable;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -44,25 +45,28 @@ public class FileTreeViewGenerator {
 			
 		} while((n=n.getNextSibling())!=null);
 		
-		int folderID = 0;
-		
+		AtomicInteger folderID = new AtomicInteger(0);
+
 		StringBuilder result = new StringBuilder();
 		result.append("<ul class='treeview'>");
 		for(FileInfo in : root.sub.values()) {
-			printFileInfo(in, result, ++folderID);
+			printFileInfo(in, result, folderID);
 		}
 		result.append("</ul>");
 		
 		return result.toString();
 	}
 	
-	static void printFileInfo(FileInfo f, StringBuilder result, int folderID) {
+	static void printFileInfo(FileInfo f, StringBuilder result, AtomicInteger folderID) {
+		String currentFolderId = "folder_" + folderID.incrementAndGet();
 		if(f.isDirectory) {
 			result.append("<li>");
-				result.append("<span class='foldername'><a role='button' data-toggle='collapse' href='#folder_" + folderID + "'>").append(f.name).append("</a></span>");
-				result.append("<ul id='folder_" + folderID + "' class='in' style='height: auto;'>");
+				result.append(String.format(
+						"<span class='foldername'><a role='button' data-toggle='collapse' href='#%s'>%s</a></span>",
+						currentFolderId, f.name));
+				result.append(String.format("<ul id='%s' class='in' style='height: auto;'>", currentFolderId));
 				for(FileInfo in : f.sub.values()) {
-					printFileInfo(in, result, ++folderID);
+					printFileInfo(in, result, folderID);
 				}
 				result.append("</ul>");
 			result.append("</li>");

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ProcessBitstreams.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ProcessBitstreams.java
@@ -218,7 +218,8 @@ public class ProcessBitstreams extends AbstractCurationTask implements Consumer 
 	                b.addMetadata( schema, element, qualifier, Item.ANY, content );
 	                //don't add more than 1000 files
 	                if(++i >= 1000){
-	                    b.addMetadata(schema, element, qualifier, Item.ANY, String.format("%s|%d", "...", 0));
+	                    b.addMetadata(schema, element, qualifier, Item.ANY, String.format("%s|%d", "... too many " +
+                                "files ...", 0));
 	                    break;
                     }
 	            }


### PR DESCRIPTION
- folderIDs are unique -> collapsing works correctly
- store `... too many files ...` instead of just `...` for large archives. Note we should update the existing previews.