### PR TITLE
Resolves #878 - Support for Google Dataset Search

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
@@ -469,6 +469,11 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
     private static class GoogleDataset{
         private static final Set<String> mandatoryFields = new HashSet<>();
         private static final HashMap<String, String> google2dspace = new HashMap<>();
+        // https://developers.google.com/search/docs/data-types/dataset#dataset specifies that description must be
+        // between 50 and 5000 characters
+        public static final int minDescriptionLength = 50;
+        public static final int maxDescriptionLength = 5000;
+
         static {
             mandatoryFields.add("name");
             mandatoryFields.add("description");
@@ -523,12 +528,12 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
 
         private void convertToValidValues(JsonObject jsonObject) {
             String description = jsonObject.get("description").getAsString();
-            if(description.length() < 50){
-                int fill = 50 - description.length();
+            if(description.length() < minDescriptionLength){
+                int fill = minDescriptionLength - description.length();
                 String filler = StringUtils.repeat('.', fill);
                 jsonObject.addProperty("description", description + filler);
-            }else if(description.length() > 5000){
-                jsonObject.addProperty("description", description.substring(0, 5000));
+            }else if(description.length() > maxDescriptionLength){
+                jsonObject.addProperty("description", description.substring(0, maxDescriptionLength));
             }
 
             if(jsonObject.has("creator")){

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
@@ -7,23 +7,28 @@
  */
 package org.dspace.app.xmlui.aspect.artifactbrowser;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
-import java.io.StringWriter;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.sql.SQLException;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletResponse;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import org.apache.cocoon.caching.CacheableProcessingComponent;
 import org.apache.cocoon.environment.ObjectModelHelper;
 import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.environment.http.HttpEnvironment;
 import org.apache.cocoon.util.HashUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.excalibur.source.SourceValidity;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
 import org.dspace.app.xmlui.utils.DSpaceValidity;
@@ -45,6 +50,7 @@ import org.dspace.app.util.GoogleMetadata;
 import org.dspace.content.crosswalk.CrosswalkException;
 import org.dspace.content.crosswalk.DisseminationCrosswalk;
 import org.dspace.core.PluginManager;
+import org.dspace.services.ConfigurationService;
 import org.jdom.Element;
 import org.jdom.Text;
 import org.jdom.output.XMLOutputter;
@@ -52,10 +58,6 @@ import org.xml.sax.SAXException;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.app.sfx.SFXFileReader;
 import org.dspace.app.xmlui.wing.element.Metadata;
-import org.dspace.content.MetadataSchema;
-import org.dspace.identifier.IdentifierNotFoundException;
-import org.dspace.identifier.IdentifierNotResolvableException;
-import org.dspace.identifier.IdentifierProvider;
 import org.dspace.utils.DSpace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -317,6 +319,16 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
             // TODO: Is this the right exception class?
             throw new WingException(ce);
         }
+
+        addGoogleDatasetInfo(pageMeta, item);
+    }
+
+    private void addGoogleDatasetInfo(PageMeta pageMeta, Item item) throws WingException {
+        ConfigurationService cs = new DSpace().getConfigurationService();
+        boolean enabled = cs.getPropertyAsType("google-dataset.enable", false);
+        if(enabled) {
+            pageMeta.addMetadata("google_dataset").addContent(new GoogleDataset(item).toString());
+        }
     }
 
     /**
@@ -452,5 +464,105 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
     public void recycle() {
     	this.validity = null;
     	super.recycle();
+    }
+
+    private static class GoogleDataset{
+        private static final Set<String> mandatoryFields = new HashSet<>();
+        private static final HashMap<String, String> google2dspace = new HashMap<>();
+        static {
+            mandatoryFields.add("name");
+            mandatoryFields.add("description");
+
+            google2dspace.put("name", "dc.title");
+            google2dspace.put("description", "dc.description");
+
+            String pathToProps = new DSpace().getConfigurationService().getPropertyAsType("google-metadata.config", "");
+            if(!pathToProps.trim().isEmpty()) {
+                Properties properties = new Properties();
+                try {
+                    BufferedReader reader = Files.newBufferedReader(Paths.get(pathToProps), StandardCharsets.UTF_8);
+                    properties.load(reader);
+                } catch (IOException e) {
+                    log.error("Exception while reading google-metadata.config", e);
+                }
+                for (String key : properties.stringPropertyNames()) {
+                    if (key.startsWith("google.dataset_")) {
+                        String googleKey = key.replace("google.dataset_", "").trim();
+                        google2dspace.put(googleKey, properties.getProperty(key).trim());
+                    }
+                }
+            }
+        }
+
+
+        private JsonObject jsonObject;
+        GoogleDataset(Item item){
+            jsonObject = new JsonObject();
+            jsonObject.addProperty("@context", "https://schema.org");
+            jsonObject.addProperty("@type", "Dataset");
+            for(Entry<String, String> entry : google2dspace.entrySet()){
+                String googleKey = entry.getKey();
+                String dspaceField = entry.getValue();
+                Metadatum[] metadata = item.getMetadataByMetadataString(dspaceField);
+                if(metadata.length == 1){
+                    jsonObject.addProperty(googleKey, metadata[0].value);
+                }else if(metadata.length > 1){
+                    JsonArray values = new JsonArray();
+                    for(Metadatum md : metadata){
+                        values.add(new JsonPrimitive(md.value));
+                    }
+                    jsonObject.add(googleKey, values);
+                }else if (mandatoryFields.contains(googleKey)){
+                    jsonObject.addProperty(googleKey, "(:unav)");
+                }else{
+                    continue;
+                }
+            }
+            convertToValidValues(jsonObject);
+        }
+
+        private void convertToValidValues(JsonObject jsonObject) {
+            String description = jsonObject.get("description").getAsString();
+            if(description.length() < 50){
+                int fill = 50 - description.length();
+                String filler = StringUtils.repeat('.', fill);
+                jsonObject.addProperty("description", description + filler);
+            }else if(description.length() > 5000){
+                jsonObject.addProperty("description", description.substring(0, 5000));
+            }
+
+            if(jsonObject.has("creator")){
+                JsonElement creator = jsonObject.get("creator");
+                JsonArray creators = new JsonArray();
+                if(creator.isJsonPrimitive()){
+                    creators.add(creatorFromString(creator.getAsString()));
+                }else if(creator.isJsonArray()){
+                    for(JsonElement creatorEl : creator.getAsJsonArray()){
+                        creators.add(creatorFromString(creatorEl.getAsString()));
+                    }
+
+                }
+                jsonObject.add("creator", creators);
+            }
+        }
+
+        private JsonElement creatorFromString(String creator) {
+            JsonObject el = new JsonObject();
+            el.addProperty("@type", "Person");
+            el.addProperty("name", creator);
+            String[] parts = creator.split(",");
+            if(parts.length > 0){
+                el.addProperty("familyName", parts[0].trim());
+            }
+            if(parts.length > 1){
+                el.addProperty("givenName", parts[1].trim());
+            }
+            return el;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("\n<script type=\"application/ld+json\">\n%s\n</script>", jsonObject.toString());
+        }
     }
 }

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/core/page-structure.xsl
@@ -286,6 +286,10 @@
 
             <link href="{concat($aaiURL, '/discojuice/discojuice.css')}" type="text/css" rel="stylesheet" />
 
+            <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google_dataset']">
+                <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google_dataset']"
+                              disable-output-escaping="yes" />
+            </xsl:if>
         </head>
     </xsl:template>
 

--- a/dspace/config/crosswalks/google-metadata.properties
+++ b/dspace/config/crosswalks/google-metadata.properties
@@ -73,5 +73,14 @@ google.citation_patent_number =
 google.citation_technical_report_number =
 google.citation_technical_report_institution = dc.publisher
 
+#uncomment to override the default mapping
+#google.dataset_name = dc.title
+#google.dataset_description = dc.description
+google.dataset_keywords = dc.subject
+google.dataset_license = dc.rights.uri
+google.dataset_url = dc.identifier.uri
+google.dataset_citation = dc.relation.isreferencedby
+google.dataset_identifier = dc.identifier.uri
+google.dataset_creator = dc.contributor.author
 
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1749,6 +1749,9 @@ webui.bitstream.order.field = bitstream_order
 ##### Google Scholar Metadata Configuration #####
 google-metadata.config = ${dspace.dir}/config/crosswalks/google-metadata.properties
 google-metadata.enable = true
+# Google dataset uses the same config file as scholar
+google-dataset.enable = true
+
 
 #---------------------------------------------------------------#
 #--------------JSPUI SPECIFIC CONFIGURATIONS--------------------#


### PR DESCRIPTION
Resolves #878 - Support for Google Dataset Search.

The default mapping (which can be overridden/extended in `dspace/config/crosswalks/google-metadata.properties`)

```
name = dc.title
description = dc.description
keywords = dc.subject
license = dc.rights.uri
url = dc.identifier.uri
citation = dc.relation.isreferencedby
identifier = dc.identifier.uri
creator = dc.contributor.author
```

`name` and `description` have a special treatment as those are mandatory; the description must fit between 50 and 5000 characters. Creator (if present) has a special treatment too, as that must be converted to object.
`DataDownload` is left out on purpose, so everyone has to go through the landing page. Moreover; many our datasets are split into multiple files and the documentation seems unclear in that matter.

This feature can be disabled in `dspace.cfg` by setting `google-dataset.enable`

This should be probably tested with https://search.google.com/test/rich-results when deployed, to see if robots.txt is set accordingly.