### PR TITLE
Fixes ufal/DSpace#917

### DIFF
--- a/dspace-api/src/test/java/cz/cuni/mff/ufal/PiwikHelperTest.java
+++ b/dspace-api/src/test/java/cz/cuni/mff/ufal/PiwikHelperTest.java
@@ -197,4 +197,12 @@ public class PiwikHelperTest {
         assertEquals("Uniq download sum differs", jsonUniqDownSum, xmlUniqDownSum);
     }
 
+    @Test
+    public void issue_917() throws Exception {
+        URL url = this.getClass().getResource("/piwik/issue_917_download_report.xml");
+        File drXml = new File(url.getFile());
+        url = this.getClass().getResource("/piwik/issue_917_view_report.xml");
+        File vrXml = new File(url.getFile());
+        PiwikHelper.mergeXML(FileUtils.readFileToString(vrXml), FileUtils.readFileToString(drXml));
+    }
 }

--- a/dspace-api/src/test/resources/piwik/issue_917_download_report.xml
+++ b/dspace-api/src/test/resources/piwik/issue_917_download_report.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result date="2020-03-01">
+		<Referrers_visitorsFromSearchEngines>0</Referrers_visitorsFromSearchEngines>
+		<Referrers_visitorsFromSocialNetworks>0</Referrers_visitorsFromSocialNetworks>
+		<Referrers_visitorsFromDirectEntry>0</Referrers_visitorsFromDirectEntry>
+		<Referrers_visitorsFromWebsites>0</Referrers_visitorsFromWebsites>
+		<Referrers_visitorsFromCampaigns>0</Referrers_visitorsFromCampaigns>
+		<Referrers_visitorsFromDirectEntry_percent>0%</Referrers_visitorsFromDirectEntry_percent>
+		<Referrers_visitorsFromSearchEngines_percent>0%</Referrers_visitorsFromSearchEngines_percent>
+		<Referrers_visitorsFromCampaigns_percent>0%</Referrers_visitorsFromCampaigns_percent>
+		<Referrers_visitorsFromSocialNetworks_percent>0%</Referrers_visitorsFromSocialNetworks_percent>
+		<Referrers_visitorsFromWebsites_percent>0%</Referrers_visitorsFromWebsites_percent>
+		<bounce_rate>0%</bounce_rate>
+		<nb_actions_per_visit>0</nb_actions_per_visit>
+		<avg_time_on_site>0</avg_time_on_site>
+		<avg_time_on_site_returning>0</avg_time_on_site_returning>
+		<nb_actions_per_visit_returning>0</nb_actions_per_visit_returning>
+		<bounce_rate_returning>0%</bounce_rate_returning>
+		<avg_time_on_site_new>0</avg_time_on_site_new>
+		<nb_actions_per_visit_new>0</nb_actions_per_visit_new>
+		<bounce_rate_new>0%</bounce_rate_new>
+	</result>
+	<result date="2020-03-02">
+		<Referrers_visitorsFromSearchEngines>0</Referrers_visitorsFromSearchEngines>
+		<Referrers_visitorsFromSocialNetworks>0</Referrers_visitorsFromSocialNetworks>
+		<Referrers_visitorsFromDirectEntry>0</Referrers_visitorsFromDirectEntry>
+		<Referrers_visitorsFromWebsites>0</Referrers_visitorsFromWebsites>
+		<Referrers_visitorsFromCampaigns>0</Referrers_visitorsFromCampaigns>
+		<Referrers_visitorsFromDirectEntry_percent>0%</Referrers_visitorsFromDirectEntry_percent>
+		<Referrers_visitorsFromSearchEngines_percent>0%</Referrers_visitorsFromSearchEngines_percent>
+		<Referrers_visitorsFromCampaigns_percent>0%</Referrers_visitorsFromCampaigns_percent>
+		<Referrers_visitorsFromSocialNetworks_percent>0%</Referrers_visitorsFromSocialNetworks_percent>
+		<Referrers_visitorsFromWebsites_percent>0%</Referrers_visitorsFromWebsites_percent>
+		<bounce_rate>0%</bounce_rate>
+		<nb_actions_per_visit>0</nb_actions_per_visit>
+		<avg_time_on_site>0</avg_time_on_site>
+		<avg_time_on_site_returning>0</avg_time_on_site_returning>
+		<nb_actions_per_visit_returning>0</nb_actions_per_visit_returning>
+		<bounce_rate_returning>0%</bounce_rate_returning>
+		<avg_time_on_site_new>0</avg_time_on_site_new>
+		<nb_actions_per_visit_new>0</nb_actions_per_visit_new>
+		<bounce_rate_new>0%</bounce_rate_new>
+	</result>
+</results>

--- a/dspace-api/src/test/resources/piwik/issue_917_view_report.xml
+++ b/dspace-api/src/test/resources/piwik/issue_917_view_report.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result date="2020-03-01">
+		<Referrers_visitorsFromSearchEngines>0</Referrers_visitorsFromSearchEngines>
+		<Referrers_visitorsFromSocialNetworks>0</Referrers_visitorsFromSocialNetworks>
+		<Referrers_visitorsFromDirectEntry>0</Referrers_visitorsFromDirectEntry>
+		<Referrers_visitorsFromWebsites>0</Referrers_visitorsFromWebsites>
+		<Referrers_visitorsFromCampaigns>0</Referrers_visitorsFromCampaigns>
+		<Referrers_visitorsFromDirectEntry_percent>0%</Referrers_visitorsFromDirectEntry_percent>
+		<Referrers_visitorsFromSearchEngines_percent>0%</Referrers_visitorsFromSearchEngines_percent>
+		<Referrers_visitorsFromCampaigns_percent>0%</Referrers_visitorsFromCampaigns_percent>
+		<Referrers_visitorsFromSocialNetworks_percent>0%</Referrers_visitorsFromSocialNetworks_percent>
+		<Referrers_visitorsFromWebsites_percent>0%</Referrers_visitorsFromWebsites_percent>
+		<bounce_rate>0%</bounce_rate>
+		<nb_actions_per_visit>0</nb_actions_per_visit>
+		<avg_time_on_site>0</avg_time_on_site>
+		<avg_time_on_site_returning>0</avg_time_on_site_returning>
+		<nb_actions_per_visit_returning>0</nb_actions_per_visit_returning>
+		<bounce_rate_returning>0%</bounce_rate_returning>
+		<avg_time_on_site_new>0</avg_time_on_site_new>
+		<nb_actions_per_visit_new>0</nb_actions_per_visit_new>
+		<bounce_rate_new>0%</bounce_rate_new>
+	</result>
+	<result date="2020-03-02">
+		<Referrers_visitorsFromSearchEngines>0</Referrers_visitorsFromSearchEngines>
+		<Referrers_visitorsFromSocialNetworks>0</Referrers_visitorsFromSocialNetworks>
+		<Referrers_visitorsFromDirectEntry>0</Referrers_visitorsFromDirectEntry>
+		<Referrers_visitorsFromWebsites>0</Referrers_visitorsFromWebsites>
+		<Referrers_visitorsFromCampaigns>0</Referrers_visitorsFromCampaigns>
+		<Referrers_visitorsFromDirectEntry_percent>0%</Referrers_visitorsFromDirectEntry_percent>
+		<Referrers_visitorsFromSearchEngines_percent>0%</Referrers_visitorsFromSearchEngines_percent>
+		<Referrers_visitorsFromCampaigns_percent>0%</Referrers_visitorsFromCampaigns_percent>
+		<Referrers_visitorsFromSocialNetworks_percent>0%</Referrers_visitorsFromSocialNetworks_percent>
+		<Referrers_visitorsFromWebsites_percent>0%</Referrers_visitorsFromWebsites_percent>
+		<bounce_rate>0%</bounce_rate>
+		<nb_actions_per_visit>0</nb_actions_per_visit>
+		<avg_time_on_site>0</avg_time_on_site>
+		<avg_time_on_site_returning>0</avg_time_on_site_returning>
+		<nb_actions_per_visit_returning>0</nb_actions_per_visit_returning>
+		<bounce_rate_returning>0%</bounce_rate_returning>
+		<avg_time_on_site_new>0</avg_time_on_site_new>
+		<nb_actions_per_visit_new>0</nb_actions_per_visit_new>
+		<bounce_rate_new>0%</bounce_rate_new>
+	</result>
+</results>


### PR DESCRIPTION
- provides a test case for the failure
- fixes the issue (missing required nodes)

@vidiecan The issue was not in the downloadReport (that seems to default to 0 correctly), but with the views report. What we have discussed is still true - for some reason we are missing some elements in the xml, it just was the other xml then I thought.