### PR TITLE
Clariah submission

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/RequiredMetadata.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/RequiredMetadata.java
@@ -147,11 +147,7 @@ public class RequiredMetadata extends AbstractCurationTask
                 	colhandle = item.getOwningCollection().getHandle();
                 	checkExtra = checkExtraIds.contains(Integer.toString(item.getOwningCollection().getID()));
                 }
-                Metadatum[] itemTypeDCV = item.getMetadata("dc", "type", null, Item.ANY);
-                String itemType = null;
-                if(itemTypeDCV != null && itemTypeDCV.length >0){
-                	itemType = itemTypeDCV[0].value;
-                }
+                Metadatum[] itemTypes = item.getMetadata(Item.ANY, "type", Item.ANY, Item.ANY);
                 for (DCInput input : getReqList(colhandle,checkExtra))
                 {
                 	StringBuilder reqsb = new StringBuilder();
@@ -177,7 +173,7 @@ public class RequiredMetadata extends AbstractCurationTask
                     
                     if (!mdPatFound) {
                         Metadatum[] vals = item.getMetadataByMetadataString(req);
-                        if ((itemType == null || input.isAllowedFor(itemType)) && vals.length == 0)
+                        if ((itemTypes == null || itemTypes.length == 0 || input.isAllowedFor(itemTypes)) && vals.length == 0)
                         {
                             boolean issue_warning = true;
                         	if (mdEquivalenceMap.containsKey(req)) {

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/app/itemimport/ItemImportReplacingMetadata.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/app/itemimport/ItemImportReplacingMetadata.java
@@ -3,6 +3,7 @@ package cz.cuni.mff.ufal.dspace.app.itemimport;
 import org.dspace.app.itemimport.ItemImport;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
+import org.dspace.content.Metadatum;
 import org.dspace.core.Context;
 import org.dspace.handle.HandleManager;
 
@@ -51,7 +52,18 @@ public class ItemImportReplacingMetadata extends ItemImport {
                 item = Item.find(c, Integer.parseInt(handle));
             }
 
+            final Metadatum[] provenance = item.getMetadataByMetadataString("dc.description.provenance");
+            final Metadatum[] accessioned = item.getMetadataByMetadataString("dc.date.accessioned");
+            final Metadatum[] available = item.getMetadataByMetadataString("dc.date.available");
+            final Metadatum[] branding = item.getMetadataByMetadataString("local.branding");
+
+            item.clearMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
             loadMetadata(c, item, java.nio.file.Paths.get(sourceDir, itemName).toString() + fs.getSeparator());
+            for (Metadatum[] mds : new Metadatum[][]{provenance, accessioned, available, branding}){
+                for(Metadatum md : mds){
+                    item.addMetadatum(md);
+                }
+            }
             processedItems.add(item);
         }
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/app/itemimport/ItemImportReplacingMetadata.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/app/itemimport/ItemImportReplacingMetadata.java
@@ -74,19 +74,26 @@ public class ItemImportReplacingMetadata extends ItemImport {
         c.commit();
         c.clearCache();
 
+        // attach license, license label requires an update
         functionalities.openSession();
         for(Item i : processedItems){
             final String licenseURI = i.getMetadata("dc.rights.uri");
             if(licenseURI != null) {
-                final int licenseId = functionalities.getLicenseByDefinition(licenseURI).getLicenseId();
+                final LicenseDefinition license = functionalities.getLicenseByDefinition(licenseURI);
+                final int licenseId = license.getLicenseId();
                 for(Bundle bundle : i.getBundles("ORIGINAL")){
                     for(Bitstream b : bundle.getBitstreams()){
                         functionalities.detachLicenses(b.getID());
                         functionalities.attachLicense(licenseId, b.getID());
                     }
                 }
+                i.clearMetadata("dc", "rights", "label", Item.ANY);
+                i.addMetadata("dc", "rights", "label", Item.ANY, license.getLicenseLabel().getLabel());
+                i.update();
             }
         }
+        c.commit();
+        c.clearCache();
         functionalities.closeSession();
     }
 }

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/app/itemimport/ItemImportReplacingMetadata.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/app/itemimport/ItemImportReplacingMetadata.java
@@ -1,0 +1,65 @@
+package cz.cuni.mff.ufal.dspace.app.itemimport;
+
+import org.dspace.app.itemimport.ItemImport;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.handle.HandleManager;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ItemImportReplacingMetadata extends ItemImport {
+
+    private java.nio.file.FileSystem fs = java.nio.file.FileSystems.getDefault();
+
+    @Override
+    protected void replaceItems(Context c, Collection[] mycollections, String sourceDir, String mapFile,
+                            boolean template) throws Exception {
+        // verify the source directory
+        File d = new java.io.File(sourceDir);
+        List<Item> processedItems = new ArrayList<>();
+
+        if (d == null || !d.isDirectory())
+        {
+            throw new Exception("Error, cannot open source directory "
+                    + sourceDir);
+        }
+
+        // read in HashMap first, to get list of handles & source dirs
+        Map<String, String> myHash = readMapFile(mapFile);
+
+        for (Map.Entry<String, String> mapEntry : myHash.entrySet())
+        {
+            String itemName = mapEntry.getKey();
+            String handle = mapEntry.getValue();
+            Item item;
+
+            if (handle.indexOf('/') != -1)
+            {
+                System.out.println("\tReplacing:  " + handle);
+
+                // add new item, locate old one
+                item = (Item) HandleManager.resolveToObject(c, handle);
+            }
+            else
+            {
+                item = Item.find(c, Integer.parseInt(handle));
+            }
+
+            loadMetadata(c, item, java.nio.file.Paths.get(sourceDir, itemName).toString() + fs.getSeparator());
+            processedItems.add(item);
+        }
+
+        //attempt at saving all changes or none;
+        for(Item i : processedItems){
+            i.update();
+        }
+        c.commit();
+        c.clearCache();
+    }
+}

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/submit/step/UFALExtraMetadataStep.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/submit/step/UFALExtraMetadataStep.java
@@ -76,13 +76,9 @@ public class UFALExtraMetadataStep extends org.dspace.submit.step.DescribeStep
         }
         
         // Fetch the document type (dc.type)
-        String documentType = "";
-        if( (item.getMetadataByMetadataString("dc.type") != null) && (item.getMetadataByMetadataString("dc.type").length >0) )
-        {
-            documentType = item.getMetadataByMetadataString("dc.type")[0].value;
-        }
-                
- 
+        Metadatum[] documentTypes = item.getMetadata(Item.ANY, "type", Item.ANY, Item.ANY);
+
+
 
         // Step 1:
         // clear out all item metadata defined on this page
@@ -115,7 +111,7 @@ public class UFALExtraMetadataStep extends org.dspace.submit.step.DescribeStep
         for (int j = 0; j < inputs.length; j++)
         {
         	// Omit fields not allowed for this document type
-            if(!inputs[j].isAllowedFor(documentType))
+            if(!inputs[j].isAllowedFor(documentTypes))
             {
             	continue;
             }
@@ -249,7 +245,7 @@ public class UFALExtraMetadataStep extends org.dspace.submit.step.DescribeStep
             {
                	// Do not check the required attribute if it is not visible or not allowed for the document type
             	String scope = subInfo.isInWorkflow() ? DCInput.WORKFLOW_SCOPE : DCInput.SUBMISSION_SCOPE;
-                if ( !( inputs[i].isVisible(scope) && inputs[i].isAllowedFor(documentType) ) )
+                if ( !( inputs[i].isVisible(scope) && inputs[i].isAllowedFor(documentTypes) ) )
                 {
                 	continue;
                 }

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -789,7 +789,7 @@ public class ItemImport
         }
     }
 
-    private void replaceItems(Context c, Collection[] mycollections,
+    protected void replaceItems(Context c, Collection[] mycollections,
             String sourceDir, String mapFile, boolean template) throws Exception
     {
         // verify the source directory
@@ -1048,7 +1048,7 @@ public class ItemImport
     // utility methods
     ////////////////////////////////////
     // read in the map file and generate a hashmap of (file,handle) pairs
-    private Map<String, String> readMapFile(String filename) throws Exception
+    protected Map<String, String> readMapFile(String filename) throws Exception
     {
         Map<String, String> myHash = new HashMap<String, String>();
 
@@ -1100,7 +1100,7 @@ public class ItemImport
     }
 
     // Load all metadata schemas into the item.
-    private void loadMetadata(Context c, Item myitem, String path)
+    protected void loadMetadata(Context c, Item myitem, String path)
             throws SQLException, IOException, ParserConfigurationException,
             SAXException, TransformerException, AuthorizeException
     {

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -55,6 +55,7 @@ public class DCInputsReader
     static final String PAIR_TYPE_NAME = "value-pairs-name";
     
     static final String COMPLEX_DEFINITION_REF = "complex-definition-ref";
+    public static final String TYPE_BIND_FIELD_ATTRIBUTE = "field";
 
     /** The fully qualified pathname of the form definition XML file */
     private String defsFile = ConfigurationManager.getProperty("dspace.dir")
@@ -495,7 +496,13 @@ public class DCInputsReader
 				} else if (tagName.equals("vocabulary")) {
 					String closedVocabularyString = getAttribute(nd, "closed");
 					field.put("closedVocabulary", closedVocabularyString);
-				}
+				} else if (tagName.equals("type-bind")){
+				    String typeField = getAttribute(nd, TYPE_BIND_FIELD_ATTRIBUTE);
+				    if(typeField == null || typeField.trim().isEmpty()){
+				        typeField = "dc.type";
+                    }
+				    field.put(TYPE_BIND_FIELD_ATTRIBUTE, typeField);
+                }
 			}
         }
         String missing = null;

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -1223,6 +1223,7 @@ public abstract class DSpaceObject
         MetadataSchema schema = MetadataSchema.find(ourContext,dcv.schema);
         if (schema == null)
         {
+            log.warn(String.format("Failed to find schema \"%s\" using dc instead.", dcv.schema));
             schemaID = MetadataSchema.DC_SCHEMA_ID;
         }
         else

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
@@ -70,6 +70,7 @@ public class DatabaseRegistryUpdater implements FlywayCallback
             MetadataImporter.loadRegistry(base + "sword-metadata.xml", true);
             MetadataImporter.loadRegistry(base + "metashareSchema.xml", true);
             MetadataImporter.loadRegistry(base + "local-types.xml", true);
+            MetadataImporter.loadRegistry(base + "edm.xml", true);
 
             // Check if XML Workflow is enabled in workflow.cfg
             if (ConfigurationManager.getProperty("workflow", "workflow.framework").equals("xmlworkflow"))

--- a/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
@@ -161,10 +161,11 @@ public class DescribeStep extends AbstractProcessingStep
         }
 
         // Fetch the document type (dc.type)
-        String documentType = "";
-        if( (item.getMetadataByMetadataString("dc.type") != null) && (item.getMetadataByMetadataString("dc.type").length >0) )
+        Metadatum[] documentTypes = null;
+        if( (item.getMetadata(Item.ANY, "type", Item.ANY, Item.ANY) != null) && (item.getMetadata(Item.ANY, "type",
+                Item.ANY, Item.ANY).length > 0) )
         {
-            documentType = item.getMetadataByMetadataString("dc.type")[0].value;
+            documentTypes = item.getMetadata(Item.ANY, "type", Item.ANY, Item.ANY);
         }
         
         // Step 1:
@@ -208,7 +209,7 @@ public class DescribeStep extends AbstractProcessingStep
         for (int j = 0; j < inputs.length; j++)
         {
         	// Omit fields not allowed for this document type
-            if(!inputs[j].isAllowedFor(documentType))
+            if(!inputs[j].isAllowedFor(documentTypes))
             {
             	continue;
             }
@@ -339,7 +340,7 @@ public class DescribeStep extends AbstractProcessingStep
             {
             	// Do not check the required attribute if it is not visible or not allowed for the document type
             	String scope = subInfo.isInWorkflow() ? DCInput.WORKFLOW_SCOPE : DCInput.SUBMISSION_SCOPE;
-                if ( !( inputs[i].isVisible(scope) && inputs[i].isAllowedFor(documentType) ) )
+                if ( !( inputs[i].isVisible(scope) && inputs[i].isAllowedFor(documentTypes) ) )
                 {
                 	continue;
                 }

--- a/dspace-oai/src/main/java/cz/cuni/mff/ufal/dspace/xoai/filter/ColComFilter.java
+++ b/dspace-oai/src/main/java/cz/cuni/mff/ufal/dspace/xoai/filter/ColComFilter.java
@@ -1,0 +1,96 @@
+package cz.cuni.mff.ufal.dspace.xoai.filter;
+
+import com.lyncode.xoai.dataprovider.core.ReferenceSet;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.solr.client.solrj.util.ClientUtils;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.handle.HandleManager;
+import org.dspace.xoai.data.DSpaceItem;
+import org.dspace.xoai.filter.DSpaceFilter;
+import org.dspace.xoai.filter.results.DatabaseFilterResult;
+import org.dspace.xoai.filter.results.SolrFilterResult;
+
+import java.sql.SQLException;
+
+public class ColComFilter extends DSpaceFilter {
+    private static Logger log = LogManager.getLogger(ColComFilter.class);
+
+    private DSpaceObject dso = null;
+
+    @Override
+    public DatabaseFilterResult buildDatabaseQuery(Context context) {
+        throw new UnsupportedOperationException("Database query not implemented.");
+    }
+
+    @Override
+    public SolrFilterResult buildSolrQuery() {
+        if (getDSpaceObject() != null) {
+            String setSpec = getSetSpec();
+            if (dso.getType() == Constants.COLLECTION) {
+                return new SolrFilterResult("-item.collections:"
+                        + ClientUtils.escapeQueryChars(setSpec));
+            } else if (dso.getType() == Constants.COMMUNITY) {
+                return new SolrFilterResult("-item.communities:"
+                        + ClientUtils.escapeQueryChars(setSpec));
+            }
+        };
+        return new SolrFilterResult("*:*");
+    }
+
+    @Override
+    public boolean isShown(DSpaceItem item) {
+        if(getDSpaceObject() != null) {
+            String setSpec = getSetSpec();
+            for (ReferenceSet s : item.getSets()) {
+                if (s.getSetSpec().equals(setSpec)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private String getSetSpec(){
+        return "hdl_" + dso.getHandle().replace("/", "_");
+    }
+
+    private DSpaceObject getDSpaceObject(){
+        if (dso == null) {
+            if(getConfiguration().get("handle") != null) {
+                String handle = getConfiguration().get("handle").asSimpleType().asString();
+                try {
+                    dso = HandleManager.resolveToObject(context, handle);
+                } catch (SQLException e) {
+                    log.error(e);
+                }
+            }else if(getConfiguration().get("name") != null){
+                String name = getConfiguration().get("name").asSimpleType().asString();
+                try {
+                    for(Community c : Community.findAll(context)){
+                       if(name.equals(c.getName())){
+                           dso = c;
+                           break;
+                       }
+                    }
+                    if(dso == null){
+                        for(Collection c : Collection.findAll(context)){
+                            if(name.equals(c.getName())){
+                                dso = c;
+                                break;
+                            }
+                        }
+                    }
+                } catch (SQLException e) {
+                    log.error(e);
+                }
+
+            }
+        }
+        return dso;
+    }
+}

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/SelectCollectionStep.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/SelectCollectionStep.java
@@ -300,6 +300,8 @@ public class SelectCollectionStep extends AbstractSubmissionStep
 
         modelJo.put("communities", communitiesJa);
 
+        modelJo.put("GUI2", configurationService.getPropertyAsType("lr.SelectCollectionStep.TopLevelOnly", false));
+
         return modelJo;
     }
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/SelectCollectionStep.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/SelectCollectionStep.java
@@ -32,6 +32,8 @@ import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Constants;
 import org.dspace.handle.HandleManager;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.xml.sax.SAXException;
@@ -73,6 +75,8 @@ public class SelectCollectionStep extends AbstractSubmissionStep
     protected static final Message T_single_collection_help = message("xmlui.Submission.submit.SelectCollection.single_collection_help");
 
     protected static final Message T_submit_next = message("xmlui.Submission.general.submission.next");
+
+    private final ConfigurationService configurationService = new DSpace().getConfigurationService();
 
     private class CommunityComparator implements Comparator<Community>
     {
@@ -312,12 +316,17 @@ public class SelectCollectionStep extends AbstractSubmissionStep
             Collection[] collections) throws SQLException
     {
         Map<Community, java.util.List<Collection>> model = new HashMap<Community, java.util.List<Collection>>();
+        boolean onlyTopLevel = configurationService.getPropertyAsType("lr.SelectCollectionStep.TopLevelOnly", false);
 
         for (Collection collection : collections)
         {
             Community[] communities = collection.getCommunities();
             for (Community community : communities)
             {
+                if(onlyTopLevel && community.getParentCommunity() != null){
+                    continue;
+                }
+
                 if (model.containsKey(community))
                 {
                     java.util.List<Collection> communityCollections = (java.util.List<Collection>) model

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/UFALExtraMetadataStep.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/UFALExtraMetadataStep.java
@@ -98,10 +98,7 @@ public class UFALExtraMetadataStep extends DescribeStep
                 String last_repeatable_component = null;
                 
                 // Fetch the document type (dc.type)
-                String documentType = "";
-                if( (item.getMetadataByMetadataString("dc.type") != null) && (item.getMetadataByMetadataString("dc.type").length >0) ) {
-                    documentType = item.getMetadataByMetadataString("dc.type")[0].value;
-                }
+                Metadatum[] documentTypes = item.getMetadata(Item.ANY, "type", Item.ANY, Item.ANY);
 
                 String scope = submissionInfo.isInWorkflow() ? DCInput.WORKFLOW_SCOPE : DCInput.SUBMISSION_SCOPE;                
                 
@@ -126,7 +123,7 @@ public class UFALExtraMetadataStep extends DescribeStep
                         }
                     }                    
                     
-                    if ( !isInputDisplayable(context, dcInput, scope, documentType ) ) 
+                    if ( !isInputDisplayable(context, dcInput, scope, documentTypes ) )
                     {
                         continue;
                     }
@@ -431,18 +428,14 @@ public class UFALExtraMetadataStep extends DescribeStep
 
         // Fetch the document type (dc.type)
         Item item = submission.getItem();
-        String documentType = "";
-        if( (item.getMetadataByMetadataString("dc.type") != null) && (item.getMetadataByMetadataString("dc.type").length >0) )
-        {
-            documentType = item.getMetadataByMetadataString("dc.type")[0].value;
-        } 
-        
+        Metadatum[] documentTypes = item.getMetadata(Item.ANY, "type", Item.ANY, Item.ANY);
+
         for (DCInput input : inputs)
         {
             // If the input is invisible in this scope, then skip it.
             String scope = submissionInfo.isInWorkflow() ? DCInput.WORKFLOW_SCOPE : DCInput.SUBMISSION_SCOPE;
             
-            if(!isInputDisplayable(context, input, scope, documentType)) {
+            if(!isInputDisplayable(context, input, scope, documentTypes)) {
                 continue;
             }                                   
             

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeStep.java
@@ -248,12 +248,8 @@ public class DescribeStep extends AbstractSubmissionStep
                 form.addItem("english-only-info", "alert alert-info").addContent(T_english_only);
 
                 // Fetch the document type (dc.type)
-                String documentType = "";
-                if( (item.getMetadataByMetadataString("dc.type") != null) && (item.getMetadataByMetadataString("dc.type").length >0) )
-                {
-                    documentType = item.getMetadataByMetadataString("dc.type")[0].value;
-                }
-                
+                Metadatum[] documentTypes = item.getMetadata(Item.ANY, "type", Item.ANY, Item.ANY);
+
                 // Iterate over all inputs and add it to the form.
                 for(DCInput dcInput : inputs)
                 {
@@ -261,7 +257,7 @@ public class DescribeStep extends AbstractSubmissionStep
                     boolean readonly = dcInput.isReadOnly(scope);
                     
                 	// Omit fields not allowed for this document type
-                    if(!dcInput.isAllowedFor(documentType))
+                    if(!dcInput.isAllowedFor(documentTypes))
                     {
                     	continue;
                     }
@@ -429,12 +425,8 @@ public class DescribeStep extends AbstractSubmissionStep
 
         // Fetch the document type (dc.type)
         Item item = submission.getItem();
-        String documentType = "";
-        if( (item.getMetadataByMetadataString("dc.type") != null) && (item.getMetadataByMetadataString("dc.type").length >0) )
-        {
-            documentType = item.getMetadataByMetadataString("dc.type")[0].value;
-        }
-        
+        Metadatum[] documentTypes = item.getMetadata(Item.ANY, "type", Item.ANY, Item.ANY);
+
 
         for (DCInput input : inputs)
         {
@@ -444,7 +436,7 @@ public class DescribeStep extends AbstractSubmissionStep
             {
                 continue;
             }
-	        if(!input.isAllowedFor(documentType))
+	        if(!input.isAllowedFor(documentTypes))
 			{
             	continue;
             }
@@ -1616,10 +1608,10 @@ public class DescribeStep extends AbstractSubmissionStep
         /**
          * should we render the metadata field based on field description?
          */
-        protected boolean isInputDisplayable(Context c, DCInput dcInput, String scope, String documentType)
+        protected boolean isInputDisplayable(Context c, DCInput dcInput, String scope, Metadatum[] documentTypes)
         {
             // Omit fields not allowed for this document type
-            if(!dcInput.isAllowedFor(documentType)) {
+            if(!dcInput.isAllowedFor(documentTypes)) {
                 return false;
             }
              

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -3235,6 +3235,15 @@
 	<message key="input_forms.field.dc.relation.isreferencedby.hint">Link to original paper that references this dataset.</message>
 	<message key="input_forms.field.dc.relation.isreferencedby.regexp-warning">The supplied url must start with http/https</message>
 
+	<message key="input_forms.field.edm.type.label">Select type of your resource</message>
+	<message key="input_forms.field.edm.type.hint">Hint TBD</message>
+	<message key="input_forms.field.edm.type.required">Please select a resource type for your submission.</message>
+	<message key="input_forms.value_pairs.edm_types.text">TEXT</message>
+	<message key="input_forms.value_pairs.edm_types.video">VIDEO</message>
+	<message key="input_forms.value_pairs.edm_types.sound">SOUND</message>
+	<message key="input_forms.value_pairs.edm_types.image">IMAGE</message>
+	<message key="input_forms.value_pairs.edm_types.3d">3D</message>
+
 	<!-- cz.cuni.mff.ufal.ContractPage -->
 	<message key="xmlui.ContractPage.title">Distribution License Agreement</message>
 	<message key="xmlui.ContractPage.trail">Distribution License Agreement</message>

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -3235,31 +3235,41 @@
 	<message key="input_forms.field.dc.relation.isreferencedby.hint">Link to original paper that references this dataset.</message>
 	<message key="input_forms.field.dc.relation.isreferencedby.regexp-warning">The supplied url must start with http/https</message>
 
-	<message key="input_forms.field.edm.type.label">Select type of your resource</message>
-	<message key="input_forms.field.edm.type.hint">Hint TBD</message>
-	<message key="input_forms.field.edm.type.required">Please select a resource type for your submission.</message>
+	<message key="input_forms.field.edm.type.label">Select the kind of resource you are submitting</message>
+	<message key="input_forms.field.edm.type.hint">Choose one of TEXT, VIDEO, SOUND, IMAGE, 3D. If choosing
+		TEXT consider adding the resource among other Language Resources.</message>
+	<message key="input_forms.field.edm.type.required">Please select one of the options.</message>
 	<message key="input_forms.value_pairs.edm_types.text">TEXT</message>
 	<message key="input_forms.value_pairs.edm_types.video">VIDEO</message>
 	<message key="input_forms.value_pairs.edm_types.sound">SOUND</message>
 	<message key="input_forms.value_pairs.edm_types.image">IMAGE</message>
 	<message key="input_forms.value_pairs.edm_types.3d">3D</message>
 
-	<message key="input_forms.field.dc.type.clariah.label">DC type label TBD</message>
-	<message key="input_forms.field.dc.type.clariah.hint">DC type hint TBD</message>
-	<message key="input_forms.field.dc.type.clariah.required">DC type required</message>
+	<message key="input_forms.field.dc.type.clariah.label">The type of the resource</message>
+	<message key="input_forms.field.dc.type.clariah.hint">The type should be different from what you have
+		entered in the first step. Examples: photo or painting for IMAGE, book or letter for TEXT, etc.</message>
+	<message key="input_forms.field.dc.type.clariah.required">Type is required</message>
 
-	<message key="input_forms.field.dc.language.iso.clariah.label">Mandatory language for TEXT</message>
-	<message key="input_forms.field.dc.language.iso.clariah.hint">Mandatory language for TEXT</message>
-	<message key="input_forms.field.dc.language.iso.clariah.required">Mandatory language for TEXT</message>
+	<message key="input_forms.field.dc.language.iso.clariah.label">Pick the languages of the TEXT</message>
+	<message key="input_forms.field.dc.language.iso.clariah.hint">Select the language of the main content of the item. Multiple languages are possible. Start
+		typing the language and use autocomplete form that will appear if applicable. Better to list all the languages then to use the 'mul' iso code (if there are too many, contact support).
+		</message>
+	<message key="input_forms.field.dc.language.iso.clariah.required">The language is required for TEXT resources</message>
 
-	<message key="input_forms.field.dc.language.iso1.clariah.label">Optional language for other types</message>
-	<message key="input_forms.field.dc.language.iso1.clariah.hint">Optional language for other types</message>
+	<message key="input_forms.field.dc.language.iso1.clariah.label">Language</message>
+	<message key="input_forms.field.dc.language.iso1.clariah.hint">Optionally, select the language of the main content
+		of the item. Multiple languages are possible. Start
+		typing the language and use autocomplete form that will appear if applicable. Better to list all the languages then to use the 'mul' iso code (if there are too many, contact support).
+	</message>
 
-	<message key="input_forms.field.dc.coverage.spatial.label">Spatial label TBD</message>
-	<message key="input_forms.field.dc.coverage.spatial.hint">Spatial hint TBD</message>
+	<message key="input_forms.field.dc.coverage.spatial.label">Spatial coverage</message>
+	<message key="input_forms.field.dc.coverage.spatial.hint">Optionally, describe places and locations the
+		resource is about.</message>
 
-	<message key="input_forms.field.dc.coverage.temporal.label">Temporal lable TBD</message>
-	<message key="input_forms.field.dc.coverage.temporal.hint">Temporal hint TBD</message>
+	<message key="input_forms.field.dc.coverage.temporal.label">Temporal coverage</message>
+	<message key="input_forms.field.dc.coverage.temporal.hint">Optionally, describe dates or periods the resources is
+		about.
+	</message>
 
 	<!-- cz.cuni.mff.ufal.ContractPage -->
 	<message key="xmlui.ContractPage.title">Distribution License Agreement</message>

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -3244,6 +3244,10 @@
 	<message key="input_forms.value_pairs.edm_types.image">IMAGE</message>
 	<message key="input_forms.value_pairs.edm_types.3d">3D</message>
 
+	<message key="input_forms.field.dc.type.clariah.label">DC type label TBD</message>
+	<message key="input_forms.field.dc.type.clariah.hint">DC type hint TBD</message>
+	<message key="input_forms.field.dc.type.clariah.required">DC type required</message>
+
 	<!-- cz.cuni.mff.ufal.ContractPage -->
 	<message key="xmlui.ContractPage.title">Distribution License Agreement</message>
 	<message key="xmlui.ContractPage.trail">Distribution License Agreement</message>

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -3248,6 +3248,13 @@
 	<message key="input_forms.field.dc.type.clariah.hint">DC type hint TBD</message>
 	<message key="input_forms.field.dc.type.clariah.required">DC type required</message>
 
+	<message key="input_forms.field.dc.language.iso.clariah.label">Mandatory language for TEXT</message>
+	<message key="input_forms.field.dc.language.iso.clariah.hint">Mandatory language for TEXT</message>
+	<message key="input_forms.field.dc.language.iso.clariah.required">Mandatory language for TEXT</message>
+
+	<message key="input_forms.field.dc.language.iso1.clariah.label">Optional language for other types</message>
+	<message key="input_forms.field.dc.language.iso1.clariah.hint">Optional language for other types</message>
+
 	<!-- cz.cuni.mff.ufal.ContractPage -->
 	<message key="xmlui.ContractPage.title">Distribution License Agreement</message>
 	<message key="xmlui.ContractPage.trail">Distribution License Agreement</message>

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -3255,6 +3255,12 @@
 	<message key="input_forms.field.dc.language.iso1.clariah.label">Optional language for other types</message>
 	<message key="input_forms.field.dc.language.iso1.clariah.hint">Optional language for other types</message>
 
+	<message key="input_forms.field.dc.coverage.spatial.label">Spatial label TBD</message>
+	<message key="input_forms.field.dc.coverage.spatial.hint">Spatial hint TBD</message>
+
+	<message key="input_forms.field.dc.coverage.temporal.label">Temporal lable TBD</message>
+	<message key="input_forms.field.dc.coverage.temporal.hint">Temporal hint TBD</message>
+
 	<!-- cz.cuni.mff.ufal.ContractPage -->
 	<message key="xmlui.ContractPage.title">Distribution License Agreement</message>
 	<message key="xmlui.ContractPage.trail">Distribution License Agreement</message>

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/js/ufal-select-collection.js
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/js/ufal-select-collection.js
@@ -16,6 +16,24 @@ ufal.selectCollection = {
 	getSelectCommunityCommunitiesListDiv : function() {
 		return $('#cz_cuni_mff_ufal_dspace_app_xmlui_aspect_submission_submit_SelectCollectionStep_div_communities-list');
 	},
+
+	div_communities: function(html) {
+		return ufal.selectCollection.getSelectCommunityCommunitiesListDiv().html(html);
+	},
+
+	getCollectionsListDiv : function(){
+		return $("#collection_list");
+	},
+
+	div_collections: function(html){
+	    var where = ufal.selectCollection.getCollectionsListDiv();
+	    if(where.length){
+	    	return where.html(html);
+		}else {
+			return ufal.selectCollection.getSelectCommunityCommunitiesListDiv().after('<hr /><div' +
+				' id="collection_list">' + html + '</div>');
+		}
+	},
 		
 	getSelectCommunityCommunitiesListLinks : function() {
 		return $('#cz_cuni_mff_ufal_dspace_app_xmlui_aspect_submission_submit_SelectCollectionStep_div_communities-list a');
@@ -37,27 +55,28 @@ ufal.selectCollection = {
 		return $('#cz_cuni_mff_ufal_dspace_app_xmlui_aspect_submission_submit_SelectCollectionStep_field_communities-model');
 	},
 	
-	createCommunitiesGUI : function(model) {
+	createGUI : function(model, key) {
 		var html = '';				
 		html += '<div style="margin-bottom:20px;">';
-		html += '<div class="well well-light" style="display: table-row;" class="text-center" id="communities">';		
-		for ( var i in model.communities) {
+		html += '<div class="well well-light" style="display: table-row;" class="text-center" id="' + key +'">';
+		for ( var i in model[key]) {
 			if(i > 0) {
 				html += '<div style="display: table-cell; vertical-align: top; width: 2%;"></div>';
 			}
-			var community = model.communities[i];
+			var communityOrCollection = model[key][i];
+			var id = key + "_" + communityOrCollection.id;
 			html += '<div style="display: table-cell; vertical-align: top; width: 49%;">';
-			html += '<a href="#" class="thumbnail" style="display: block; line-height: inherit; padding: 1em 2em;" id="community_' + community.id + '">';			
-			if (community.logoURL != "") {
+			html += '<a href="#" class="thumbnail" style="display: block; line-height: inherit; padding: 1em 2em;" id="' + id + '">';
+			if (communityOrCollection.logoURL != "") {
 				html += '<div style="line-height: 200px; text-align: center;">';
-				html += '<img src="' + community.logoURL + '" alt="'
-						+ community.name + '" />';
+				html += '<img src="' + communityOrCollection.logoURL + '" alt="'
+						+ communityOrCollection.name + '" />';
 				html += '</div>';
 			}			
 			html += '<div style="min-height: 7em;">';
-			html += '<h4 class="text-center">' + community.name + '</h4>';
-			if (community.shortDescription != "") {
-				html += '<p>' + community.shortDescription + '</p>';
+			html += '<h4 class="text-center">' + communityOrCollection.name + '</h4>';
+			if (communityOrCollection.shortDescription != "") {
+				html += '<p>' + communityOrCollection.shortDescription + '</p>';
 			}
 			html += '</div>';
 			html += '</a>';
@@ -66,8 +85,12 @@ ufal.selectCollection = {
 		}		
 		html += '</div>';
 		html += '</div>';
-		ufal.selectCollection.getSelectCommunityCommunitiesListDiv().html(html);		
+		var appendTo = ufal.selectCollection['div_' + key](html);
 	},
+
+	createCommunitiesGUI : function(model) {
+		ufal.selectCollection.createGUI(model, 'communities');
+    },
 
 	getCommunitiesModel : function() {
 		var model = {};
@@ -89,7 +112,7 @@ ufal.selectCollection = {
 					select.append('<option value="' + collection.handle + '">'
 							+ collection.name + '</option>');
 				}
-				break;
+				return community;
 			}
 		}
 	},		
@@ -111,10 +134,33 @@ ufal.selectCollection = {
 		else {
 			ufal.selectCollection.getSelectCollectionSubmitButton().removeAttr('disabled');
 		}
+		$('html, body').delay(100).animate({
+			scrollTop: ufal.selectCollection.getSelectCollectionDiv().offset().top
+		}, 200);
 	},
-	
-	showNextButtonOnly : function() {		
-		ufal.selectCollection.getSelectCollectionDiv().hide();		
+
+	showCollectionsGUI2 : function(community, collectionSelect) {
+		ufal.selectCollection.createGUI(community, 'collections');
+		ufal.selectCollection.getCollectionsListDiv().find("a").on('click', function(){
+			var name = $(this).attr('id');
+			var collectionID = name.replace(/^.*_(\d+)/, '$1');
+			var handle;
+			for (var i in community.collections){
+				var collection = community.collections[i];
+				if(collection.id == collectionID){
+					handle = collection.handle;
+					break;
+				}
+			}
+			if(handle) {
+				collectionSelect.find('option[value="' + handle + '"]').prop('selected', true);
+				ufal.selectCollection.getSelectCollectionSubmitButton().removeAttr('disabled');
+			}
+		});
+	},
+
+	showNextButtonOnly : function() {
+			ufal.selectCollection.getSelectCollectionDiv().hide();
 		ufal.selectCollection.getSelectCollectionSubmitButton().removeAttr('disabled');
 	},
 	
@@ -123,17 +169,18 @@ ufal.selectCollection = {
 		$(this).toggleClass('alert-info');			
 		var name = $(this).attr('id');
 		var communityID = name.replace(/^.*_(\d+)/, '$1');
-		ufal.selectCollection.populateCollections(communityID, ufal.selectCollection.model);
+		var community = ufal.selectCollection.populateCollections(communityID, ufal.selectCollection.model);
 		var collectionSelect = ufal.selectCollection.getSelectCollectionSelect();
 		if(collectionSelect.find('option').length == 2) {
 			collectionSelect.find('option:eq(1)').prop('selected', true);
 			ufal.selectCollection.showNextButtonOnly();			
 		}
 		else {
-			ufal.selectCollection.showCollectionsGUI();								
-			$('html, body').delay(100).animate({
-		        scrollTop: ufal.selectCollection.getSelectCollectionDiv().offset().top		        
-		    }, 200);
+			if(ufal.selectCollection.model.GUI2){
+				ufal.selectCollection.showCollectionsGUI2(community, collectionSelect)
+			}else{
+				ufal.selectCollection.showCollectionsGUI();
+			}
 		}
 		return false;
 	},

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/js/ufal-select-collection.js
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/js/ufal-select-collection.js
@@ -142,7 +142,12 @@ ufal.selectCollection = {
 	showCollectionsGUI2 : function(community, collectionSelect) {
 		ufal.selectCollection.createGUI(community, 'collections');
 		ufal.selectCollection.getCollectionsListDiv().find("a").on('click', function(){
-			var name = $(this).attr('id');
+			ufal.selectCollection.getCollectionsListDiv().find(".alert-info").each(function(){
+				$(this).removeClass('alert-info');
+			});
+			var $this = $(this);
+			$this.toggleClass('alert-info');
+			var name = $this.attr('id');
 			var collectionID = name.replace(/^.*_(\d+)/, '$1');
 			var handle;
 			for (var i in community.collections){

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -388,10 +388,20 @@
 												<i18n:text>xmlui.dri2xhtml.METS-1.0.item-type</i18n:text>
 					</dt>
 					<dd>
-						<a>
-							<xsl:attribute name="href"><xsl:copy-of select="$contextPath"/>/browse?value=<xsl:value-of select="dim:field[@element='type'][not(@qualifier)][1]/node()" />&amp;type=type</xsl:attribute>
-							<xsl:value-of select="dim:field[@element='type'][not(@qualifier)][1]/node()" />
-						</a>							
+						<xsl:for-each
+								select="dim:field[@element='type' and not(@qualifier)]">
+							<xsl:sort select="." />
+							<a>
+								<xsl:attribute name="href">
+									<xsl:value-of
+											select="concat($contextPath, '/discover?filtertype=type&amp;filter_relational_operator=equals&amp;filter=',encoder:encode(.))"/>
+								</xsl:attribute>
+								<xsl:value-of select="." />
+							</a>
+							<xsl:if test="position() != last()">
+								<xsl:text>, </xsl:text>
+							</xsl:if>
+						</xsl:for-each>
 					</dd>
 				</dl>
 				<xsl:call-template name="itemSummaryView-DIM-fields">

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -381,7 +381,7 @@
 
 			<!-- type row -->
 			<xsl:when
-				test="$clause = 9 and (dim:field[@element='type' and not(@qualifier)])">
+				test="$clause = 9 and ((dim:field[@element='type' and not(@qualifier)]) or (dim:field[@qualifier='mediaType']))">
 					<dl id="item-type" class="dl-horizontal">
 					<dt style="text-align: left">
 						<i class="fa fa-tag">&#160;</i>
@@ -389,7 +389,7 @@
 					</dt>
 					<dd>
 						<xsl:for-each
-								select="dim:field[@element='type' and not(@qualifier)]">
+								select="dim:field[(@element='type' and not(@qualifier)) or @qualifier='mediaType']">
 							<xsl:sort select="." />
 							<a>
 								<xsl:attribute name="href">

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/core/forms.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/core/forms.xsl
@@ -1216,7 +1216,7 @@
 <!-- Special Handling for submissions -->
 
 	<xsl:template
-			match="dri:item[dri:field[@id='aspect.submission.StepTransformer.field.dc_type' and not(contains('no-thumbs', @rend))]]"
+			match="dri:item[dri:field[@id='aspect.submission.StepTransformer.field.dc_type' and not(contains(@rend, 'no-thumbs'))]]"
 				  priority="10">
                 <div>
                         <xsl:attribute name='class'>

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/core/forms.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/core/forms.xsl
@@ -1215,7 +1215,9 @@
 
 <!-- Special Handling for submissions -->
 
-	<xsl:template match="dri:item[dri:field[@id='aspect.submission.StepTransformer.field.dc_type']]" priority="10">
+	<xsl:template
+			match="dri:item[dri:field[@id='aspect.submission.StepTransformer.field.dc_type' and not(contains('no-thumbs', @rend))]]"
+				  priority="10">
                 <div>
                         <xsl:attribute name='class'>
                                 <xsl:if test='dri:field/dri:error'>

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -138,6 +138,7 @@
 		    <XSLT>metadataFormats/lindat_cmdi.xsl</XSLT>
 		    <Namespace>http://www.clarin.eu/cmd/</Namespace>
 		    <SchemaLocation>http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1349361150622/xsd</SchemaLocation>
+            <Filter ref="ExcludeItemsInComOrCol"/>
 		</Format>
         <Format id="olac">
                <Prefix>olac</Prefix>
@@ -181,6 +182,11 @@
         <Filter id="openaireFilter">
             <Definition>
                                 <Custom ref="openaireRelationCondition"/>
+            </Definition>
+        </Filter>
+        <Filter id="ExcludeItemsInComOrCol">
+            <Definition>
+                <Custom ref="cmdiExcludedComsOrCols"/>
             </Definition>
         </Filter>
 
@@ -434,6 +440,13 @@
             <Class>org.dspace.xoai.filter.DSpaceMetadataExistsFilter</Class>
             <Configuration>
                 <string name="field">metashare.ResourceInfo#ContentInfo.mediaType</string>
+            </Configuration>
+        </CustomCondition>
+
+        <CustomCondition id="cmdiExcludedComsOrCols">
+            <Class>cz.cuni.mff.ufal.dspace.xoai.filter.ColComFilter</Class>
+            <Configuration>
+                <string name="handle">XXX</string>
             </Configuration>
         </CustomCondition>
     </Filters>

--- a/dspace/config/input-forms.dtd
+++ b/dspace/config/input-forms.dtd
@@ -29,6 +29,7 @@
  <!ELEMENT dc-element (#PCDATA) >
  <!ELEMENT dc-qualifier (#PCDATA) >
  <!ELEMENT type-bind (#PCDATA) >
+ <!ATTLIST type-bind field CDATA #IMPLIED >
  
  <!ELEMENT repeatable (#PCDATA) >
  <!ELEMENT repeatable-component (#PCDATA) >

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -589,6 +589,30 @@
                 </field>
 
                 <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>coverage</dc-element>
+                    <dc-qualifier>spatial</dc-qualifier>
+                    <!-- An input-type of twobox MUST be marked as repeatable -->
+                    <repeatable>true</repeatable>
+                    <repeatable-parse>true</repeatable-parse>
+                    <label>input_forms.field.dc.coverage.spatial.label</label>
+                    <input-type>twobox</input-type>
+                    <hint>input_forms.field.dc.coverage.spatial.hint</hint>
+                </field>
+
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>covarage</dc-element>
+                    <dc-qualifier>temporal</dc-qualifier>
+                    <!-- An input-type of twobox MUST be marked as repeatable -->
+                    <repeatable>true</repeatable>
+                    <repeatable-parse>true</repeatable-parse>
+                    <label>input_forms.field.dc.coverage.temporal.label</label>
+                    <input-type>twobox</input-type>
+                    <hint>input_forms.field.dc.coverage.temporal.hint</hint>
+                </field>
+
+                <field>
                     <dc-schema>local</dc-schema>
                     <dc-element>size</dc-element>
                     <dc-qualifier>info</dc-qualifier>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -602,7 +602,7 @@
 
                 <field>
                     <dc-schema>dc</dc-schema>
-                    <dc-element>covarage</dc-element>
+                    <dc-element>coverage</dc-element>
                     <dc-qualifier>temporal</dc-qualifier>
                     <!-- An input-type of twobox MUST be marked as repeatable -->
                     <repeatable>true</repeatable>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -533,6 +533,7 @@
                     <input-type>onebox</input-type>
                     <hint>input_forms.field.dc.type.hint</hint>
                     <required>input_forms.field.dc.type.required</required>
+                    <class>no-thumbs</class>
                 </field>
                 <!-- describe the resource -->
                 <field>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -673,6 +673,72 @@
 
             </page>
         </form>
+
+        <form name="clariah_submissions">
+            <page number="1">
+                <field>
+                    <dc-schema>local</dc-schema>
+                    <dc-element>submission</dc-element>
+                    <dc-qualifier>note</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>input_forms.field.local.submission.note.label</label>
+                    <input-type>textarea</input-type>
+                    <hint>input_forms.field.local.submission.note.hint</hint>
+                    <required/>
+                </field>
+
+                <!-- DC.Relation.Replaces -->
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>relation</dc-element>
+                    <dc-qualifier>replaces</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>input_forms.field.dc.relation.replaces.label</label>
+                    <input-type>onebox</input-type>
+                    <hint>input_forms.field.dc.relation.replaces.hint</hint>
+                    <autocomplete>solr-handle_title_ac</autocomplete>
+                    <required/>
+                    <component-label> </component-label>
+                    <collapsible>Special fields</collapsible>
+                </field>
+
+                <!-- DC.Relation.IsReplacedBy -->
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>relation</dc-element>
+                    <dc-qualifier>isreplacedby</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>input_forms.field.dc.relation.isreplacedby.label</label>
+                    <input-type>onebox</input-type>
+                    <hint>input_forms.field.dc.relation.isreplacedby.hint</hint>
+                    <autocomplete>solr-handle_title_ac</autocomplete>
+                    <required/>
+                    <component-label> </component-label>
+                    <acl>
+                        policy=deny,action=read,grantee-type=user,grantee-id=*
+                    </acl>
+                </field>
+
+                <!-- Local.Embargo.TermsLift -->
+                <field>
+                    <dc-schema>local</dc-schema>
+                    <dc-element>embargo</dc-element>
+                    <dc-qualifier>termslift</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>input_forms.field.local.embargo.termslift.label</label>
+                    <input-type>onebox</input-type>
+                    <hint>input_forms.field.local.embargo.termslift.hint</hint>
+                    <required/>
+                    <regexp>\d\d\d\d-\d\d-\d\d</regexp>
+                    <regexp-warning>input_forms.field.local.embargo.termslift.regexp-warning</regexp-warning>
+                    <component-label> </component-label>
+                    <acl>
+                        policy=deny,action=read,grantee-type=user,grantee-id=*
+                    </acl>
+                </field>
+
+            </page>
+        </form>
     </form-definitions-extra>
 
 
@@ -744,23 +810,23 @@
         </value-pairs>
         <value-pairs value-pairs-name="edm_types" dc-term="edm.type">
             <pair>
-            <displayed-value>TEXT</displayed-value>
+            <displayed-value>input_forms.value_pairs.edm_types.text</displayed-value>
             <stored-value>TEXT</stored-value>
             </pair>
             <pair>
-            <displayed-value>VIDEO</displayed-value>
+            <displayed-value>input_forms.value_pairs.edm_types.video</displayed-value>
             <stored-value>VIDEO</stored-value>
             </pair>
             <pair>
-            <displayed-value>SOUND</displayed-value>
+            <displayed-value>input_forms.value_pairs.edm_types.sound</displayed-value>
             <stored-value>SOUND</stored-value>
             </pair>
             <pair>
-            <displayed-value>IMAGE</displayed-value>
+            <displayed-value>input_forms.value_pairs.edm_types.image</displayed-value>
             <stored-value>IMAGE</stored-value>
             </pair>
             <pair>
-            <displayed-value>3D</displayed-value>
+            <displayed-value>input_forms.value_pairs.edm_types.3d</displayed-value>
             <stored-value>3D</stored-value>
             </pair>
         </value-pairs>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -372,7 +372,6 @@
                         date
                         +admin only fields-->
 
-                <!-- TODO generic type TEXT/IMAGE/ETC -->
                 <field>
                     <dc-schema>edm</dc-schema>
                     <dc-element>type</dc-element>
@@ -532,6 +531,7 @@
                     <label>input_forms.field.dc.type.clariah.label</label>
                     <input-type>onebox</input-type>
                     <hint>input_forms.field.dc.type.clariah.hint</hint>
+                    <autocomplete>solr-dctype_ac</autocomplete>
                     <required>input_forms.field.dc.type.clariah.required</required>
                     <class>no-thumbs</class>
                 </field>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -14,7 +14,7 @@
     <form-map>
         <name-map collection-handle="default" form-name="traditional"/>
         <!-- TODO real handle -->
-        <name-map collection-handle="123456789/2888" form-name="clariah_submissions"/>
+        <name-map collection-handle="123456789/2" form-name="clariah_submissions"/>
     </form-map>
 
 
@@ -529,10 +529,10 @@
                     <dc-element>type</dc-element>
                     <dc-qualifier/>
                     <repeatable>false</repeatable>
-                    <label>input_forms.field.dc.type.label</label>
+                    <label>input_forms.field.dc.type.clariah.label</label>
                     <input-type>onebox</input-type>
-                    <hint>input_forms.field.dc.type.hint</hint>
-                    <required>input_forms.field.dc.type.required</required>
+                    <hint>input_forms.field.dc.type.clariah.hint</hint>
+                    <required>input_forms.field.dc.type.clariah.required</required>
                     <class>no-thumbs</class>
                 </field>
                 <!-- describe the resource -->

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -553,13 +553,12 @@
                     <dc-element>language</dc-element>
                     <dc-qualifier>iso</dc-qualifier>
                     <repeatable>true</repeatable>
-                    <label>input_forms.field.dc.language.iso.label</label>
-                    <!-- todo inspect the typebind -->
+                    <label>input_forms.field.dc.language.iso.clariah.label</label>
                     <type-bind field="edm.type">TEXT</type-bind>
                     <input-type>onebox</input-type>
-                    <hint>input_forms.field.dc.language.iso.hint</hint>
+                    <hint>input_forms.field.dc.language.iso.clariah.hint</hint>
                     <autocomplete>json_static-iso_langs.json</autocomplete>
-                    <required>input_forms.field.dc.language.iso.required</required>
+                    <required>input_forms.field.dc.language.iso.clariah.required</required>
                 </field>
 
                 <field>
@@ -567,11 +566,10 @@
                     <dc-element>language</dc-element>
                     <dc-qualifier>iso</dc-qualifier>
                     <repeatable>true</repeatable>
-                    <label>input_forms.field.dc.language.iso1.label</label>
-                    <!-- todo inspect the typebind -->
-                    <type-bind>toolService</type-bind>
+                    <label>input_forms.field.dc.language.iso1.clariah.label</label>
+                    <type-bind field="edm.type">VIDEO,IMAGE,SOUND,3D</type-bind>
                     <input-type>onebox</input-type>
-                    <hint>input_forms.field.dc.language.iso1.hint</hint>
+                    <hint>input_forms.field.dc.language.iso1.clariah.hint</hint>
                     <autocomplete>json_static-iso_langs.json</autocomplete>
                     <required/>
                 </field>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -13,6 +13,8 @@
 
     <form-map>
         <name-map collection-handle="default" form-name="traditional"/>
+        <!-- TODO real handle -->
+        <name-map collection-handle="123456789/2888" form-name="clariah_submissions"/>
     </form-map>
 
 
@@ -358,6 +360,227 @@
                     <required/>
                 </field>
             </page>
+        </form>
+
+        <form name="clariah_submissions">
+            <page number="1">
+
+                <!-- Basic info
+                        +type for type binds
+                        title
+                      demoUrl
+                        date
+                        +admin only fields-->
+
+                <!-- TODO generic type TEXT/IMAGE/ETC -->
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>type</dc-element>
+                    <dc-qualifier/>
+                    <repeatable>false</repeatable>
+                    <label>input_forms.field.dc.type.label</label>
+                    <input-type value-pairs-name="common_types">dropdown</input-type>
+                    <hint>input_forms.field.dc.type.hint</hint>
+                    <required>input_forms.field.dc.type.required</required>
+                </field>
+
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>title</dc-element>
+                    <dc-qualifier/>
+                    <repeatable>false</repeatable>
+                    <label>input_forms.field.dc.title.label</label>
+                    <input-type>onebox</input-type>
+                    <hint>input_forms.field.dc.title.hint</hint>
+                    <required>input_forms.field.dc.title.required</required>
+                </field>
+
+                <field>
+                    <dc-schema>local</dc-schema>
+                    <dc-element>demo</dc-element>
+                    <dc-qualifier>uri</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>input_forms.field.local.demo.uri.label</label>
+                    <input-type>onebox</input-type>
+                    <hint>input_forms.field.local.demo.uri.hint</hint>
+                    <required/>
+                    <regexp>http.*</regexp>
+                    <regexp-warning>input_forms.field.local.demo.uri.regexp-warning</regexp-warning>
+                </field>
+
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>relation</dc-element>
+                    <dc-qualifier>isreferencedby</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>input_forms.field.dc.relation.isreferencedby.label</label>
+                    <input-type>onebox</input-type>
+                    <hint>input_forms.field.dc.relation.isreferencedby.hint</hint>
+                    <required/>
+                    <regexp>http.*</regexp>
+                    <regexp-warning>input_forms.field.dc.relation.isreferencedby.regexp-warning</regexp-warning>
+                </field>
+
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>date</dc-element>
+                    <dc-qualifier>issued</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>input_forms.field.dc.date.issued.label</label>
+                    <input-type>FormattedDate</input-type>
+                    <hint>input_forms.field.dc.date.issued.hint</hint>
+                    <required>input_forms.field.dc.date.issued.required</required>
+                    <class>with-datepicker</class>
+                </field>
+
+                <field>
+                    <dc-schema>local</dc-schema>
+                    <dc-element>hidden</dc-element>
+                    <dc-qualifier/>
+                    <repeatable>false</repeatable>
+                    <label>input_forms.field.local.hidden.label</label>
+                    <input-type value-pairs-name="hidden_list">list</input-type>
+                    <hint>input_forms.field.local.hidden.hint</hint>
+                    <required/>
+                    <acl>
+                        policy=deny,action=read,grantee-type=user,grantee-id=*
+                    </acl>
+                </field>
+
+                <field>
+                    <dc-schema>local</dc-schema>
+                    <dc-element>hasMetadata</dc-element>
+                    <dc-qualifier/>
+                    <repeatable>false</repeatable>
+                    <label>input_forms.field.local.hasMetadata.label</label>
+                    <input-type value-pairs-name="metashare_languageDependent">list</input-type>
+                    <!-- true/false value -->
+                    <hint>input_forms.field.local.hasMetadata.hint</hint>
+                    <required/>
+                    <acl>
+                        policy=deny,action=read,grantee-type=user,grantee-id=*
+                    </acl>
+                </field>
+
+            </page>
+
+            <page number="2">
+
+                <!-- who's involved
+                        authors
+                        publisher
+                        funding
+                        contact
+                -->
+
+
+                <!-- todo decide this -->
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>contributor</dc-element>
+                    <dc-qualifier>author</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>input_forms.field.dc.contributor.author.label</label>
+                    <input-type>name</input-type>
+                    <hint>input_forms.field.dc.contributor.author.hint</hint>
+                    <autocomplete>solr-author_ac-specific</autocomplete>
+                    <required>input_forms.field.dc.contributor.author.required</required>
+                </field>
+
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>publisher</dc-element>
+                    <dc-qualifier/>
+                    <repeatable>true</repeatable>
+                    <label>input_forms.field.dc.publisher.label</label>
+                    <input-type>onebox</input-type>
+                    <hint>input_forms.field.dc.publisher.hint</hint>
+                    <autocomplete>solr-publisher_ac</autocomplete>
+                    <required>input_forms.field.dc.publisher.required</required>
+                </field>
+
+                <field>
+                    <dc-schema>local</dc-schema>
+                    <dc-element>contact</dc-element>
+                    <dc-qualifier>person</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>input_forms.field.local.contact.person.label</label>
+                    <input-type complex-definition-ref="contact_person">complex</input-type>
+                    <hint>input_forms.field.local.contact.person.hint</hint>
+                    <required>input_forms.field.local.contact.person.required</required>
+                </field>
+
+
+                <field>
+                    <dc-schema>local</dc-schema>
+                    <dc-element>sponsor</dc-element>
+                    <repeatable>true</repeatable>
+                    <label>input_forms.field.local.sponsor.label</label>
+                    <input-type complex-definition-ref="funding">complex</input-type>
+                    <hint>input_forms.field.local.sponsor.hint</hint>
+                </field>
+
+
+            </page>
+
+            <page number="3">
+                <!-- describe the resource -->
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <dc-qualifier/>
+                    <repeatable>false</repeatable>
+                    <label>input_forms.field.dc.description.label</label>
+                    <input-type>textarea</input-type>
+                    <hint>input_forms.field.dc.description.hint</hint>
+                    <required>input_forms.field.dc.description.required</required>
+                </field>
+
+
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>language</dc-element>
+                    <dc-qualifier>iso</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>input_forms.field.dc.language.iso.label</label>
+                    <!-- todo inspect the typebind -->
+                    <type-bind>TEXT</type-bind>
+                    <input-type>onebox</input-type>
+                    <hint>input_forms.field.dc.language.iso.hint</hint>
+                    <autocomplete>json_static-iso_langs.json</autocomplete>
+                    <required>input_forms.field.dc.language.iso.required</required>
+                </field>
+
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>language</dc-element>
+                    <dc-qualifier>iso</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>input_forms.field.dc.language.iso1.label</label>
+                    <!-- todo inspect the typebind -->
+                    <type-bind>toolService</type-bind>
+                    <input-type>onebox</input-type>
+                    <hint>input_forms.field.dc.language.iso1.hint</hint>
+                    <autocomplete>json_static-iso_langs.json</autocomplete>
+                    <required/>
+                </field>
+
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>subject</dc-element>
+                    <dc-qualifier/>
+                    <!-- An input-type of twobox MUST be marked as repeatable -->
+                    <repeatable>true</repeatable>
+                    <repeatable-parse>true</repeatable-parse>
+                    <label>input_forms.field.dc.subject.label</label>
+                    <input-type>twobox</input-type>
+                    <hint>input_forms.field.dc.subject.hint</hint>
+                    <autocomplete>solr-subject_ac</autocomplete>
+                    <required>input_forms.field.dc.subject.required</required>
+                </field>
+            </page>
+
+
         </form>
     </form-definitions>
 

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -374,14 +374,14 @@
 
                 <!-- TODO generic type TEXT/IMAGE/ETC -->
                 <field>
-                    <dc-schema>dc</dc-schema>
+                    <dc-schema>edm</dc-schema>
                     <dc-element>type</dc-element>
                     <dc-qualifier/>
                     <repeatable>false</repeatable>
-                    <label>input_forms.field.dc.type.label</label>
-                    <input-type value-pairs-name="common_types">dropdown</input-type>
-                    <hint>input_forms.field.dc.type.hint</hint>
-                    <required>input_forms.field.dc.type.required</required>
+                    <label>input_forms.field.edm.type.label</label>
+                    <input-type value-pairs-name="edm_types">dropdown</input-type>
+                    <hint>input_forms.field.edm.type.hint</hint>
+                    <required>input_forms.field.edm.type.required</required>
                 </field>
 
                 <field>
@@ -524,6 +524,16 @@
             </page>
 
             <page number="3">
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>type</dc-element>
+                    <dc-qualifier/>
+                    <repeatable>false</repeatable>
+                    <label>input_forms.field.dc.type.label</label>
+                    <input-type>onebox</input-type>
+                    <hint>input_forms.field.dc.type.hint</hint>
+                    <required>input_forms.field.dc.type.required</required>
+                </field>
                 <!-- describe the resource -->
                 <field>
                     <dc-schema>dc</dc-schema>
@@ -730,6 +740,28 @@
             <!--<pair> <displayed-value>Evaluation package</displayed-value> <stored-value>evaluationPackage</stored-value>
               </pair> -->
 
+        </value-pairs>
+        <value-pairs value-pairs-name="edm_types" dc-term="edm.type">
+            <pair>
+            <displayed-value>TEXT</displayed-value>
+            <stored-value>TEXT</stored-value>
+            </pair>
+            <pair>
+            <displayed-value>VIDEO</displayed-value>
+            <stored-value>VIDEO</stored-value>
+            </pair>
+            <pair>
+            <displayed-value>SOUND</displayed-value>
+            <stored-value>SOUND</stored-value>
+            </pair>
+            <pair>
+            <displayed-value>IMAGE</displayed-value>
+            <stored-value>IMAGE</stored-value>
+            </pair>
+            <pair>
+            <displayed-value>3D</displayed-value>
+            <stored-value>3D</stored-value>
+            </pair>
         </value-pairs>
 
         <!-- default language order: (from dspace 1.2.1) langauges are in languages.js

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -587,6 +587,16 @@
                     <autocomplete>solr-subject_ac</autocomplete>
                     <required>input_forms.field.dc.subject.required</required>
                 </field>
+
+                <field>
+                    <dc-schema>local</dc-schema>
+                    <dc-element>size</dc-element>
+                    <dc-qualifier>info</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>input_forms.field.local.size.info.label</label>
+                    <input-type complex-definition-ref="clariahSizeInfo">complex</input-type>
+                    <hint>input_forms.field.local.size.info.hint</hint>
+                </field>
             </page>
 
 
@@ -1322,6 +1332,12 @@
         <definition name="sizeInfo">
             <input name="1_size" type="text" regexp="\d+.?\d*" required="true"/>
             <input name="2_unit" type="dropdown" pairs="metashare_sizeunit" label="input_forms.complex_definitions.sizeInfo.2_unit.label" required="true"/>
+        </definition>
+
+        <definition name="clariahSizeInfo">
+        <input name="1_size" type="text" regexp="\d+.?\d*" required="true"/>
+        <input name="2_unit" type="text" label="input_forms.complex_definitions.sizeInfo.2_unit.label"
+               required="true" autocomplete="solr-local.size.info_comp"/>
         </definition>
     </form-complex-definitions>
 

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -555,7 +555,7 @@
                     <repeatable>true</repeatable>
                     <label>input_forms.field.dc.language.iso.label</label>
                     <!-- todo inspect the typebind -->
-                    <type-bind>TEXT</type-bind>
+                    <type-bind field="edm.type">TEXT</type-bind>
                     <input-type>onebox</input-type>
                     <hint>input_forms.field.dc.language.iso.hint</hint>
                     <autocomplete>json_static-iso_langs.json</autocomplete>

--- a/dspace/config/modules/lr.cfg
+++ b/dspace/config/modules/lr.cfg
@@ -312,3 +312,5 @@ ${navigation.cite.link}
 ${navigation.lifecycle.link}
 ${navigation.faq.link}
 ${navigation.about.link}
+
+${lr.SelectCollectionStep.TopLevelOnly}

--- a/dspace/config/registries/edm.xml
+++ b/dspace/config/registries/edm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dspace-dc-types>
+    <dc-schema>
+        <name>edm</name>
+        <namespace>http://www.europeana.eu/schemas/edm/</namespace>
+    </dc-schema>
+    <dc-type>
+        <schema>edm</schema>
+        <element>type</element>
+        <qualifier/>
+        <scope_note>The value must be one of the types accepted by Europeana as it will support portal functionality: TEXT, VIDEO, SOUND, IMAGE, 3D.</scope_note>
+    </dc-type>
+</dspace-dc-types>
+
+

--- a/dspace/config/registries/edm.xml
+++ b/dspace/config/registries/edm.xml
@@ -8,7 +8,9 @@
         <schema>edm</schema>
         <element>type</element>
         <qualifier/>
-        <scope_note>The value must be one of the types accepted by Europeana as it will support portal functionality: TEXT, VIDEO, SOUND, IMAGE, 3D.</scope_note>
+        <scope_note>The value must be one of the types accepted by Europeana as it will support portal functionality: TEXT, VIDEO, SOUND, IMAGE, 3D.
+        There's a huge overlap with values we allow in metashare's mediaType; eventually this might get merged.
+        </scope_note>
     </dc-type>
 </dspace-dc-types>
 

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -463,6 +463,7 @@
         <property name="facetLimit" value="5"/>
         <property name="sortOrder" value="COUNT"/>
         <property name="splitter" value="::"/>
+        <property name="skipFirstNodeLevel" value="false"/>
 		<property name="fullAutoComplete" value="true"/>
     </bean>
     <bean id="searchFilterRights" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">	

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -516,6 +516,7 @@
         <property name="metadataFields">
             <list>
                 <value>dc.type</value>
+                <value>edm.type</value>
             </list>
         </property>
         <property name="facetLimit" value="5"/>
@@ -602,6 +603,7 @@
         <property name="metadataFields">
             <list>
                 <value>dc.type</value>
+                <value>edm.type</value>
             </list>
         </property>
         <property name="facetLimit" value="20"/>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -114,6 +114,7 @@
 		        <ref bean="searchFilterPublisher" />
 		        <ref bean="searchFilterLanguage" />
 		        <ref bean="searchFilterType" />
+                <ref bean="searchFacetDcType" />
             </list>
         </property>
         <!--The sort filters for the discovery search-->
@@ -609,7 +610,18 @@
         <property name="facetLimit" value="20"/>
         <property name="sortOrder" value="COUNT"/>
     </bean>
-    
+
+    <bean id="searchFacetDcType" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="dctype"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.type</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="20"/>
+        <property name="sortOrder" value="COUNT"/>
+    </bean>
+
     <bean id="searchFacetFile" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="hasfile"/>
         <property name="metadataFields">

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -518,6 +518,7 @@
             <list>
                 <value>dc.type</value>
                 <value>edm.type</value>
+                <value>metashare.ResourceInfo#ContentInfo.mediaType</value>
             </list>
         </property>
         <property name="facetLimit" value="5"/>
@@ -605,6 +606,7 @@
             <list>
                 <value>dc.type</value>
                 <value>edm.type</value>
+                <value>metashare.ResourceInfo#ContentInfo.mediaType</value>
             </list>
         </property>
         <property name="facetLimit" value="20"/>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -3518,6 +3518,12 @@
 	<message key="input_forms.field.dc.language.iso1.clariah.label">Optional language for other types</message>
 	<message key="input_forms.field.dc.language.iso1.clariah.hint">Optional language for other types</message>
 
+	<message key="input_forms.field.dc.coverage.spatial.label">Spatial label TBD</message>
+	<message key="input_forms.field.dc.coverage.spatial.hint">Spatial hint TBD</message>
+
+	<message key="input_forms.field.dc.coverage.temporal.label">Temporal lable TBD</message>
+	<message key="input_forms.field.dc.coverage.temporal.hint">Temporal hint TBD</message>
+
 	<!-- cz.cuni.mff.ufal.ContractPage -->
 	<message key="xmlui.ContractPage.title">Smlouva o distribuci dat</message>
 	<message key="xmlui.ContractPage.trail">Smlouva o distribuci dat</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -3507,6 +3507,10 @@
 	<message key="input_forms.value_pairs.edm_types.image">IMAGE</message>
 	<message key="input_forms.value_pairs.edm_types.3d">3D</message>
 
+	<message key="input_forms.field.dc.type.clariah.label">DC type label TBD</message>
+	<message key="input_forms.field.dc.type.clariah.hint">DC type hint TBD</message>
+	<message key="input_forms.field.dc.type.clariah.required">DC type required</message>
+
 	<!-- cz.cuni.mff.ufal.ContractPage -->
 	<message key="xmlui.ContractPage.title">Smlouva o distribuci dat</message>
 	<message key="xmlui.ContractPage.trail">Smlouva o distribuci dat</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -3511,6 +3511,13 @@
 	<message key="input_forms.field.dc.type.clariah.hint">DC type hint TBD</message>
 	<message key="input_forms.field.dc.type.clariah.required">DC type required</message>
 
+	<message key="input_forms.field.dc.language.iso.clariah.label">Mandatory language for TEXT</message>
+	<message key="input_forms.field.dc.language.iso.clariah.hint">Mandatory language for TEXT</message>
+	<message key="input_forms.field.dc.language.iso.clariah.required">Mandatory language for TEXT</message>
+
+	<message key="input_forms.field.dc.language.iso1.clariah.label">Optional language for other types</message>
+	<message key="input_forms.field.dc.language.iso1.clariah.hint">Optional language for other types</message>
+
 	<!-- cz.cuni.mff.ufal.ContractPage -->
 	<message key="xmlui.ContractPage.title">Smlouva o distribuci dat</message>
 	<message key="xmlui.ContractPage.trail">Smlouva o distribuci dat</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -3498,31 +3498,34 @@
 	<message key="input_forms.field.dc.relation.isreferencedby.hint">Odkaz na původní článek, který zmiňuje tento záznam.</message>
 	<message key="input_forms.field.dc.relation.isreferencedby.regexp-warning">URL musi začínat http/https</message>
 
-	<message key="input_forms.field.edm.type.label">Select type of your resource</message>
-	<message key="input_forms.field.edm.type.hint">Hint TBD</message>
-	<message key="input_forms.field.edm.type.required">Please select a resource type for your submission.</message>
+	<message key="input_forms.field.edm.type.label">Zvolte druh záznamu</message>
+	<message key="input_forms.field.edm.type.hint">Vyberte z TEXT, VIDEO, ZVUK, OBRAZ, 3D. Pokud zvolíte TEXT,
+		zvažte, jestli se nejedná o Language Resource (Jazykový zdroj).</message>
+	<message key="input_forms.field.edm.type.required">Zvolte prosím jednu z možností</message>
 	<message key="input_forms.value_pairs.edm_types.text">TEXT</message>
 	<message key="input_forms.value_pairs.edm_types.video">VIDEO</message>
-	<message key="input_forms.value_pairs.edm_types.sound">SOUND</message>
-	<message key="input_forms.value_pairs.edm_types.image">IMAGE</message>
+	<message key="input_forms.value_pairs.edm_types.sound">ZVUK</message>
+	<message key="input_forms.value_pairs.edm_types.image">OBRAZ</message>
 	<message key="input_forms.value_pairs.edm_types.3d">3D</message>
 
-	<message key="input_forms.field.dc.type.clariah.label">DC type label TBD</message>
-	<message key="input_forms.field.dc.type.clariah.hint">DC type hint TBD</message>
-	<message key="input_forms.field.dc.type.clariah.required">DC type required</message>
+	<message key="input_forms.field.dc.type.clariah.label">Typ záznamu</message>
+	<message key="input_forms.field.dc.type.clariah.hint">Typ by měl být odlišný od druhu, který jste zvolili v
+		prvním kroku. Například: fotografie nebo malba pro druh OBRAZ, kniha nebo dopis pro typ TEXT apod.</message>
+	<message key="input_forms.field.dc.type.clariah.required">Vyplňte typ</message>
 
-	<message key="input_forms.field.dc.language.iso.clariah.label">Mandatory language for TEXT</message>
-	<message key="input_forms.field.dc.language.iso.clariah.hint">Mandatory language for TEXT</message>
-	<message key="input_forms.field.dc.language.iso.clariah.required">Mandatory language for TEXT</message>
+	<message key="input_forms.field.dc.language.iso.clariah.label">Vyberte jazyky TEXTu</message>
+	<message key="input_forms.field.dc.language.iso.clariah.hint">Vyberte jazyky, jichž se data tohoto záznamu týkají. Je možné zvolit více jazyků. Začnete-li psát, objeví se nápověda. Je lepší vyjmenovat všechny dotčené jazyky (pokud jich je větší množství, kontaktujte podporu), než používat iso kód 'mul'. </message>
+	<message key="input_forms.field.dc.language.iso.clariah.required">Pro TEXTy je jazyk povinný</message>
 
-	<message key="input_forms.field.dc.language.iso1.clariah.label">Optional language for other types</message>
-	<message key="input_forms.field.dc.language.iso1.clariah.hint">Optional language for other types</message>
+	<message key="input_forms.field.dc.language.iso1.clariah.label">Jazyk</message>
+	<message key="input_forms.field.dc.language.iso1.clariah.hint">Volitelné. Vyberte jazyky, jichž se data tohoto záznamu týkají. Je možné zvolit více jazyků. Začnete-li psát, objeví se nápověda. Je lepší vyjmenovat všechny dotčené jazyky (pokud jich je větší množství, kontaktujte podporu), než používat iso kód 'mul'. </message>
 
-	<message key="input_forms.field.dc.coverage.spatial.label">Spatial label TBD</message>
-	<message key="input_forms.field.dc.coverage.spatial.hint">Spatial hint TBD</message>
+	<message key="input_forms.field.dc.coverage.spatial.label">Místa</message>
+	<message key="input_forms.field.dc.coverage.spatial.hint">Volitelné. Uveďte místa, o kterých zdroj je.</message>
 
-	<message key="input_forms.field.dc.coverage.temporal.label">Temporal lable TBD</message>
-	<message key="input_forms.field.dc.coverage.temporal.hint">Temporal hint TBD</message>
+	<message key="input_forms.field.dc.coverage.temporal.label">Období</message>
+	<message key="input_forms.field.dc.coverage.temporal.hint">Volitelné. Uveďte data, období, epochy apod., o
+	kterých zdroj je.</message>
 
 	<!-- cz.cuni.mff.ufal.ContractPage -->
 	<message key="xmlui.ContractPage.title">Smlouva o distribuci dat</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -3498,6 +3498,15 @@
 	<message key="input_forms.field.dc.relation.isreferencedby.hint">Odkaz na původní článek, který zmiňuje tento záznam.</message>
 	<message key="input_forms.field.dc.relation.isreferencedby.regexp-warning">URL musi začínat http/https</message>
 
+	<message key="input_forms.field.edm.type.label">Select type of your resource</message>
+	<message key="input_forms.field.edm.type.hint">Hint TBD</message>
+	<message key="input_forms.field.edm.type.required">Please select a resource type for your submission.</message>
+	<message key="input_forms.value_pairs.edm_types.text">TEXT</message>
+	<message key="input_forms.value_pairs.edm_types.video">VIDEO</message>
+	<message key="input_forms.value_pairs.edm_types.sound">SOUND</message>
+	<message key="input_forms.value_pairs.edm_types.image">IMAGE</message>
+	<message key="input_forms.value_pairs.edm_types.3d">3D</message>
+
 	<!-- cz.cuni.mff.ufal.ContractPage -->
 	<message key="xmlui.ContractPage.title">Smlouva o distribuci dat</message>
 	<message key="xmlui.ContractPage.trail">Smlouva o distribuci dat</message>


### PR DESCRIPTION
install notes:
import edm md schema
new community gets handle.prefix
community filiator to move old comms
new communities don't have any groups assigned
collection ids in input-forms
cmdi export setup?
communities pid setup (new pid!) (nest open an l/c in subcommunities)

======
what's in here:
 - type bind on other fields than dc.type (*.type.*.*)
   - with field atttribute, eg. `type-bind field="edm.type"`
 - ItemImportReplacingMetadata
   - invoke like this `bin/dspace import -a -e admin@example.com -c 123456789/123 -s /import -m /import/mapfile.txt --replace --extending-class cz.cuni.mff.ufal.dspace.app.itemimport.ItemImportReplacingMetadata`
 - oai col/com filter
   - don't expose whole collection community (selectable either with handle or name) under a certain metadata prefix
 - new gui for select collection step (draws only top level communities and then collections)
  - lr.SelectCollectionStep.TopLevelOnly
 - item-view: mediaType showed next to any(dc., edm.) type
 - search filter/facet type includes edm & mediaType (+dc.type)
 - new searchFacetDcType for autocomplete in submission (not attached to discovery advanced)
 - draft of "non linguistic data" submission
 - edm schema (questionable if needed), draft