### PR TITLE
update for ufal/clarin-dspace#878 (google datasets)

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1751,6 +1751,7 @@ google-metadata.config = ${dspace.dir}/config/crosswalks/google-metadata.propert
 google-metadata.enable = true
 # Google dataset uses the same config file as scholar
 google-dataset.enable = true
+${google-dataset.blacklistedTypes}
 
 
 #---------------------------------------------------------------#


### PR DESCRIPTION
New configurables:
 - blacklisted dc.types for which the metadata won't be added
 - by default does not add metadata for items with no bitstreams

see also ufal/clarin-dspace#878 and ufal/clarin-dspace#916