### PR TITLE
Attempt at fixing issue where no json was produced by the rest api

### DIFF
--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
-        <jersey.version>2.27</jersey.version>
+        <jersey.version>2.30.1</jersey.version>
     </properties>
     <build>
         <plugins>

--- a/dspace-rest/src/main/java/org/dspace/rest/common/DSpaceObject.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/DSpaceObject.java
@@ -37,7 +37,7 @@ public class DSpaceObject {
     @XmlElement(name = "link", required = true)
     private String link;
 
-    private ArrayList<String> expand = new ArrayList<String>();
+    private List<String> expand = new ArrayList<String>();
 
     public DSpaceObject() {
 
@@ -92,7 +92,7 @@ public class DSpaceObject {
         return expand;
     }
 
-    public void setExpand(ArrayList<String> expand) {
+    public void setExpand(List<String> expand) {
         this.expand = expand;
     }
 


### PR DESCRIPTION
The jersey version update is there to get exception logging from
`org.eclipse.persistence.jaxb.rs.MOXyJsonProvider`.

Then fixing the following exception:
```
Descriptor Exceptions:
---------------------------------------------------------

Exception [EclipseLink-60] (Eclipse Persistence Services -
2.7.4.v20190115-ad5b7c6b2a):
org.eclipse.persistence.exceptions.DescriptorException
Exception Description: The method [setExpand] or [getExpand] is not
defined in the object [org.dspace.rest.common.DSpaceObject].
Internal Exception: java.lang.NoSuchMethodException:
org.dspace.rest.common.DSpaceObject.setExpand(java.util.List)
Mapping:
org.eclipse.persistence.oxm.mappings.XMLCompositeDirectCollectionMapping[expand]
Descriptor: XMLDescriptor(org.dspace.rest.common.DSpaceObject -->
[DatabaseTable(dspaceobject)])

Runtime Exceptions:
---------------------------------------------------------
```