### PR TITLE
Updated javax.mail implementation

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -389,8 +389,8 @@
             <artifactId>commons-validator</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -47,8 +47,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
         <dependency> <!-- Keep jmockit before junit -->
             <groupId>org.jmockit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1085,9 +1085,9 @@
 	          <version>1.6</version>
 	      </dependency>
          <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-            <version>1.4</version>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
+            <version>1.6.2</version>
          </dependency>
          <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
To fix:
```
INVALID HEADER: DUPLICATE HEADER FIELD
  Header field occurs more than once: "To" occurs 3 times
along with an Undelivered Mail Returned to Sender message
```

@cyplas If you could test this...run `make clean_source` before pulling the changes