### PR TITLE
Tweaking right hand side menu

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/Navigation.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/Navigation.java
@@ -36,6 +36,7 @@ import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.services.ConfigurationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
@@ -101,7 +102,9 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
 
 	/** Cached validity object */
 	private SourceValidity validity;
-	
+
+	private static final ConfigurationService configurationService= new org.dspace.utils.DSpace().getConfigurationService();
+
     /**
      * Generate the unique key.
      * This key must be unique inside the space of this component.
@@ -250,11 +253,16 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
         
         // about
         about.setHead( T_about_head );
-        about.addItemXref( contextPath + "/page/deposit", T_deposit );
-        about.addItemXref( contextPath + "/page/cite", T_cite);
-        about.addItemXref( contextPath + "/page/item-lifecycle", T_lifecycle );
-        about.addItemXref( contextPath + "/page/faq", T_faq);
-        about.addItemXref( contextPath + "/page/about", T_about );
+        about.addItemXref(configurationService.getPropertyAsType("lr.navigation.deposit.link", contextPath + "/page/deposit"),
+                T_deposit);
+        about.addItemXref(configurationService.getPropertyAsType("lr.navigation.cite.link", contextPath + "/page/cite"),
+                T_cite);
+        about.addItemXref(configurationService.getPropertyAsType("lr.navigation.lifecycle.link", contextPath + "/page/item-lifecycle"),
+                T_lifecycle );
+        about.addItemXref(configurationService.getPropertyAsType("lr.navigation.faq.link", contextPath + "/page/faq"),
+                T_faq);
+        about.addItemXref(configurationService.getPropertyAsType("lr.navigation.about.link", contextPath + "/page/about"),
+                T_about );
         about.addItem().addXref("mailto:" + ConfigurationManager.getProperty("lr.help.mail"),T_helpdesk, "helpdesk");
         
         //context

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/core/navigation.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/core/navigation.xsl
@@ -54,7 +54,7 @@
 				</xsl:if>
 				<xsl:apply-templates select="dri:list[count(child::*)!=0]" />
 				<xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='feed']">
-					<li class="always-open">
+					<li class="">
 						<xsl:call-template name="addRSSLinks" />
 					</li>				
 				</xsl:if>
@@ -268,7 +268,7 @@
 
     <!-- Add each RSS feed from meta to a list -->
     <xsl:template name="addRSSLinks">
-        <a>
+        <a href="#" class="dropdown-toggle">
                 <i class="fa fa-rss-square ">&#160;</i>
                 <span class="menu-text">
                         RSS Feed

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/core/navigation.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/core/navigation.xsl
@@ -52,9 +52,6 @@
 						</div>					
 					</li>
 				</xsl:if>
-				<li class="always-open hidden-xs">
-					<xsl:call-template name="howto-panel" />
-				</li>
 				<xsl:apply-templates select="dri:list[count(child::*)!=0]" />
 				<xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='feed']">
 					<li class="always-open">
@@ -318,27 +315,6 @@
 	</xsl:template>
 
     
-    <xsl:template name="howto-panel">
-                <a>
-                        <i class="fa fa-question-circle">&#160;</i>
-                        <span class="menu-text">
-							<i18n:text>xmlui.UFAL.navigation.menu_head</i18n:text>
-                        </span>
-                </a>
-                <ul class="submenu" style="padding-bottom: 8px;">
-                        <li>
-                        <a href="{$context-path}/page/deposit" style="border-top: none; padding: 7px 0px 8px 18px">
-                                <img src="{$context-path}/themes/UFALHome/lib/images/deposit.png" align="left" class="deposit" />
-                        </a>
-                        </li>
-                        <li>
-                                <a href="{$context-path}/page/cite" style="border-top: none; padding: 7px 0px 8px 18px;">
-                                <img src="{$context-path}/themes/UFALHome/lib/images/cite.png" align="right" class="cite" />
-                                </a>
-                        </li>
-                </ul>
-    </xsl:template>
-
 	<xsl:template name="navbar">
 		<nav class="navbar-fixed-top">
 			<div class="container-fluid">

--- a/dspace/config/modules/lr.cfg
+++ b/dspace/config/modules/lr.cfg
@@ -306,3 +306,9 @@ description.location = ${lr.description.location}
 description.country = ${lr.description.country}
 description.city = ${lr.description.city}
 
+### Links in navigation
+${navigation.deposit.link}
+${navigation.cite.link}
+${navigation.lifecycle.link}
+${navigation.faq.link}
+${navigation.about.link}


### PR DESCRIPTION
resolves #863 

- removes deposit/cite image links from the menu
- rss feeds are collapsible and collapsed by default
- general info links are configurable. With no configuration they stay the same, to change them put the following (example) in `local.properties`:

```
### Links in navigation
navigation.deposit.link = navigation.deposit.link = https://lindat.cz/faq-repository#what-is-deposit-procedure
navigation.cite.link = navigation.cite.link = https://lindat.cz/faq-repository#how-to-cite
navigation.lifecycle.link = navigation.lifecycle.link = https://lindat.cz/faq-repository#what-is-deposited-item-lifecycle
navigation.faq.link = navigation.faq.link = https://lindat.cz/faq-repository
navigation.about.link = navigation.about.link = https://lindat.cz/faq-repository#what-is-the-repository
```