### PR TITLE
Update openaire crosswalk based on feedback

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/datacite_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/datacite_openaire.xsl
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- Created for LINDAT/CLARIN based on DIM2DataCite https://guidelines.openaire.eu/wiki/OpenAIRE_Guidelines:_For_Data_Archives -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:doc="http://www.lyncode.com/xoai"
-    xmlns:xalan="http://xml.apache.org/xslt"
-	exclude-result-prefixes="doc xalan" version="1.0">
+				xmlns:doc="http://www.lyncode.com/xoai"
+				xmlns:xalan="http://xml.apache.org/xslt"
+				xmlns:odc="http://schema.datacite.org/oai/oai-1.1/"
+				xmlns="http://datacite.org/schema/kernel-3"
+				exclude-result-prefixes="doc xalan" version="1.0">
 	<xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
 
     <!-- TODO implement Required & optional templates -->
 	<xsl:template match="/">
-		<oai_datacite>
-			<isReferenceQuality>true</isReferenceQuality>
-			<schemaVersion>3.0</schemaVersion>
-			<datacentreSymbol></datacentreSymbol>
-			<payload>
+		<odc:oai_datacite>
+			<odc:schemaVersion>3.1</odc:schemaVersion>
+			<odc:datacentreSymbol></odc:datacentreSymbol>
+			<odc:payload>
 				<resource>
 					<xsl:call-template name="Identifier_M" />
 					<xsl:call-template name="Creator_M" />
@@ -33,8 +34,8 @@
 					<xsl:call-template name="Description_MA" />
 					<xsl:call-template name="GeoLocation_R" />
 				</resource>
-			</payload>
-		</oai_datacite>
+			</odc:payload>
+		</odc:oai_datacite>
 	</xsl:template>
 
 	<xsl:template name="Identifier_M">

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -149,8 +149,8 @@
 		<Format id="oai_datacite">
 		       <Prefix>oai_datacite</Prefix>
 		       <XSLT>metadataFormats/datacite_openaire.xsl</XSLT>
-		       <Namespace>http://schema.datacite.org/oai/oai-1.0/</Namespace>
-		       <SchemaLocation>http://schema.datacite.org/oai/oai-1.0/oai.xsd</SchemaLocation>
+		       <Namespace>http://schema.datacite.org/oai/oai-1.1/</Namespace>
+		       <SchemaLocation>http://schema.datacite.org/oai/oai-1.1/oai.xsd</SchemaLocation>
 		</Format>
 		<Format id="html">
 		    <Prefix>html</Prefix>


### PR DESCRIPTION
adding namespace declarations to resource and oai_datacite
datacite oai 1.1 removes isReferenceQuality
bump of schema version from 3.0. to 3.1 should be ok.