### PR TITLE
Configurable refbox

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -957,8 +957,8 @@ public class ItemImport
                 try {
                     InstallItem.installItem(c, wi, myhandle);
                 } catch (Exception e) {
-                    wi.deleteAll();
                     log.error("Exception after install item, try to revert...", e);
+                    wi.deleteAll();
                     throw e;
                 }
 

--- a/dspace/config/crosswalks/oai/metadataFormats/html.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/html.xsl
@@ -13,38 +13,52 @@
     <xsl:variable name="authorsLimitLT" select="4"/>
 
     <xsl:output omit-xml-declaration="yes" method="xml" indent="yes" cdata-section-elements="h:html"/>
+
+    <xsl:variable name="title"><xsl:call-template name="title"/></xsl:variable>
+    <xsl:variable name="authors"><xsl:call-template name="authors"/></xsl:variable>
+    <xsl:variable name="pid"><xsl:call-template name="pid"/></xsl:variable>
+    <xsl:variable name="repository"><xsl:call-template name="repository"/></xsl:variable>
+    <xsl:variable name="year"><xsl:call-template name="year"/></xsl:variable>
+    <xsl:variable name="publisher"><xsl:call-template name="publisher"/></xsl:variable>
+
     <xsl:template match="/">
+
         <h:html xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://lindat.mff.cuni.cz/ns/experimental/html http://lindat.mff.cuni.cz/schemas/experimental/html.xsd">
-            <xsl:variable name="title"><xsl:call-template name="title"/></xsl:variable>
-            <xsl:variable name="authors"><xsl:call-template name="authors"/></xsl:variable>
-            <xsl:variable name="pid"><xsl:call-template name="pid"/></xsl:variable>
-            <xsl:variable name="repository"><xsl:call-template name="repository"/></xsl:variable>
-            <xsl:variable name="year"><xsl:call-template name="year"/></xsl:variable>
             <xsl:choose>
-                    <xsl:when test="$authors != ''">
-                        <xsl:copy-of select="$authors"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']"/>
-                    </xsl:otherwise>
+            <xsl:when
+                    test="doc:metadata/doc:element[@name='local']/doc:element[@name='refbox']/doc:element[@name='format']/doc:element/doc:field[@name='value']/text()">
+                <xsl:call-template name="interpolate-variables">
+                    <xsl:with-param name="value" select="doc:metadata/doc:element[@name='local']/doc:element[@name='refbox']/doc:element[@name='format']/doc:element/doc:field[@name='value']/text()"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                    <xsl:choose>
+                        <xsl:when test="$authors != ''">
+                            <xsl:copy-of select="$authors"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$publisher"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                    <xsl:if test="$year != ''">
+                        <xsl:text>, </xsl:text>
+                        <xsl:copy-of select="$year"/>
+                    </xsl:if>
+                    <xsl:if test="$title != ''">
+                        <xsl:text>, </xsl:text>
+                        <xsl:copy-of select="$title"/>
+                    </xsl:if>
+                    <xsl:if test="$repository != ''">
+                        <xsl:text>, </xsl:text>
+                        <xsl:copy-of select="$repository"/>
+                    </xsl:if>
+                    <xsl:if test="$pid != ''">
+                        <xsl:text>, </xsl:text>
+                        <xsl:copy-of select="$pid"/>
+                    </xsl:if>
+                    <xsl:text>.</xsl:text>
+            </xsl:otherwise>
             </xsl:choose>
-            <xsl:if test="$year != ''">
-                <xsl:text>, </xsl:text>
-                <xsl:copy-of select="$year"/>
-            </xsl:if>
-            <xsl:if test="$title != ''">
-                <xsl:text>, </xsl:text>
-                <xsl:copy-of select="$title"/>
-            </xsl:if>
-            <xsl:if test="$repository != ''">
-                <xsl:text>, </xsl:text>
-                <xsl:copy-of select="$repository"/>
-            </xsl:if>
-            <xsl:if test="$pid != ''">
-                <xsl:text>, </xsl:text>
-                <xsl:copy-of select="$pid"/>
-            </xsl:if>
-            <xsl:text>.</xsl:text>
         </h:html>
     </xsl:template>
 
@@ -99,5 +113,76 @@
         <xsl:if test="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value']">
             <xsl:value-of select="substring(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value'],1,4)"/>
         </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="publisher">
+        <xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']"/>
+    </xsl:template>
+
+    <xsl:template name="interpolate-variables">
+        <xsl:param name="value" />
+        <xsl:choose>
+            <xsl:when
+                    test="contains($value, '{title}') or contains($value, '{authors}') or contains($value, '{pid}') or contains($value, '{repository}') or contains($value, '{year}') or contains($value, '{publisher}')">
+                <xsl:choose>
+                    <xsl:when test="starts-with($value,'{title}')">
+                        <xsl:copy-of select="$title"/>
+                        <xsl:call-template name="interpolate-variables">
+                            <xsl:with-param name="value" select="substring-after($value,'{title}')"/>
+                        </xsl:call-template>
+                    </xsl:when>
+                    <xsl:when test="starts-with($value,'{authors}')">
+                        <xsl:copy-of select="$authors"/>
+                        <xsl:call-template name="interpolate-variables">
+                            <xsl:with-param name="value" select="substring-after($value,'{authors}')"/>
+                        </xsl:call-template>
+                    </xsl:when>
+                    <xsl:when test="starts-with($value,'{pid}')">
+                        <xsl:copy-of select="$pid"/>
+                        <xsl:call-template name="interpolate-variables">
+                            <xsl:with-param name="value" select="substring-after($value,'{pid}')"/>
+                        </xsl:call-template>
+                    </xsl:when>
+                    <xsl:when test="starts-with($value,'{repository}')">
+                        <xsl:copy-of select="$repository"/>
+                        <xsl:call-template name="interpolate-variables">
+                            <xsl:with-param name="value" select="substring-after($value,'{repository}')"/>
+                        </xsl:call-template>
+                    </xsl:when>
+                    <xsl:when test="starts-with($value,'{year}')">
+                        <xsl:copy-of select="$year"/>
+                        <xsl:call-template name="interpolate-variables">
+                            <xsl:with-param name="value" select="substring-after($value,'{year}')"/>
+                        </xsl:call-template>
+                    </xsl:when>
+                    <xsl:when test="starts-with($value,'{publisher}')">
+                        <xsl:copy-of select="$publisher"/>
+                        <xsl:call-template name="interpolate-variables">
+                            <xsl:with-param name="value" select="substring-after($value,'{publisher}')"/>
+                        </xsl:call-template>
+                    </xsl:when>
+                    <!-- we have a known variable but not at the start -->
+                    <xsl:otherwise>
+                        <xsl:choose>
+                            <xsl:when test="starts-with($value, '{')">
+                                <xsl:value-of select="'{'"/>
+                                <xsl:call-template name="interpolate-variables">
+                                    <xsl:with-param name="value" select="substring-after($value, '{')"/>
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="substring-before($value, '{')"/>
+                                <xsl:call-template name="interpolate-variables">
+                                    <xsl:with-param name="value" select="concat('{', substring-after($value, '{'))"/>
+                                </xsl:call-template>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$value" />
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 </xsl:stylesheet>

--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -117,6 +117,13 @@
         <qualifier>reason</qualifier>
         <scope_note>Store the withdrawal reason in addition to provenance</scope_note>
     </dc-type>
+    <dc-type>
+        <schema>local</schema>
+        <element>refbox</element>
+        <qualifier>format</qualifier>
+        <scope_note>If the default refbox citation is not enough, use this field to provide a format string
+            . Check/extend html.xsl for available variables.</scope_note>
+    </dc-type>
 </dspace-dc-types>
 
 


### PR DESCRIPTION
to install import local-types registry
to use set metadata field local.refbox.format to a format string (can contain text + variables one of: `{title}, {authors}, {publisher}, {year}, {pid}, {repository}`