### PR TITLE
Present the authors in details/summary tags

### DIFF
--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -2973,6 +2973,8 @@
   <message key="xmlui.UFAL.artifactbrowser.item_view.licensed_under">This item is {0} and licensed under:<BR/></message>
   <message key="xmlui.UFAL.artifactbrowser.item_view.preview">Preview</message>
   <message key="xmlui.UFAL.artifactbrowser.item_view.file_preview">File Preview</message>
+  <message key="xmlui.UFAL.artifactbrowser.item_view.show_all_authors">show everyone</message>
+
 
 
 	<!-- UFAL/lib/xsl/core/navigation.xsl -->

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-list.xsl
@@ -280,22 +280,7 @@
             <div class="author">
                 <xsl:choose>
                     <xsl:when test="dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']">
-                        <xsl:for-each
-                            select="dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']">
-                            <span>
-                                <xsl:if test="@authority">
-                                    <xsl:attribute name="class"><xsl:text>ds-dc_contributor_author-authority</xsl:text></xsl:attribute>
-                                </xsl:if>
-                                <a>
-									<xsl:attribute name="href"><xsl:copy-of select="$context-path"/>/browse?value=<xsl:copy-of select="node()" />&amp;type=author</xsl:attribute>
-									<xsl:copy-of select="node()" />
-								</a>                                
-                            </span>
-                            <xsl:if
-                                test="count(following-sibling::dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']) != 0">
-                                <xsl:text>; </xsl:text>
-                            </xsl:if>
-                        </xsl:for-each>
+			    <xsl:call-template name="authors_with_short_summary_view"/>
                     </xsl:when>
                     <xsl:when test="dim:field[@element='creator']">
                         <xsl:for-each select="dim:field[@element='creator']">
@@ -476,7 +461,6 @@
         </div>
         <xsl:apply-templates select="dri:field" />
     </xsl:template>    
-            
 </xsl:stylesheet>
 
 

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -188,23 +188,9 @@
 					<dd style="padding-right: 40px;">
 					<xsl:choose>
 						<xsl:when test="dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']">
-							<xsl:for-each
-								select="dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']">
-								<span>
-									<xsl:if test="@authority">
-										<xsl:attribute name="class"><xsl:text>ds-dc_contributor_author-authority</xsl:text></xsl:attribute>
-									</xsl:if>
-									<a>
-								<xsl:attribute name="href"><xsl:copy-of select="$contextPath"/>/browse?value=<xsl:copy-of select="node()" />&amp;type=author</xsl:attribute>
-								<xsl:copy-of select="node()" />
-								</a>
-
-								</span>
-								<xsl:if
-									test="count(following-sibling::dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']) != 0">
-									<xsl:text>; </xsl:text>
-								</xsl:if>
-							</xsl:for-each>
+							<xsl:call-template name="authors_with_short_summary_view">
+								<xsl:with-param name="contextPath" select="$contextPath"/>
+							</xsl:call-template>
 						</xsl:when>
 						<xsl:when test="dim:field[@element='creator']">
 							<xsl:for-each select="dim:field[@element='creator']">
@@ -1230,6 +1216,63 @@
                </button>
            </div>
        </div>
+    </xsl:template>
+
+    <xsl:template name="authors_with_short_summary_view">
+	<xsl:param name="contextPath"/>
+	<xsl:choose>
+		<xsl:when test="count(dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']) &gt; 3">
+			<details>
+				<summary>
+
+					<xsl:for-each select="dim:field[@element='contributor'][@qualifier='author' or @qualifier='other'][position() &lt;= 3]">
+						<xsl:call-template name="print_author">
+							<xsl:with-param name="contextPath" select="$contextPath"/>
+						</xsl:call-template>
+						<xsl:text>;</xsl:text>
+					</xsl:for-each>
+					<xsl:text> et al.</xsl:text>
+					<span style="display: list-item"><i18n:text>xmlui.UFAL.artifactbrowser.item_view.show_all_authors</i18n:text></span>
+				</summary>
+				<xsl:call-template name="print_all_authors">
+					<xsl:with-param name="contextPath" select="$contextPath"/>
+				</xsl:call-template>
+			</details>
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:call-template name="print_all_authors">
+				<xsl:with-param name="contextPath" select="$contextPath"/>
+			</xsl:call-template>
+		</xsl:otherwise>
+	</xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="print_all_authors">
+	    <xsl:param name="contextPath"/>
+	<xsl:for-each
+		select="dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']">
+		<xsl:call-template name="print_author">
+			<xsl:with-param name="contextPath" select="$contextPath"/>
+		</xsl:call-template>
+		<xsl:if
+			test="count(following-sibling::dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']) != 0">
+			<xsl:text>; </xsl:text>
+		</xsl:if>
+	</xsl:for-each>
+    </xsl:template>
+
+    <xsl:template name="print_author">
+    	<xsl:param name="contextPath" select="$context-path"/>
+	<span>
+		<xsl:if test="@authority">
+			<xsl:attribute name="class"><xsl:text>ds-dc_contributor_author-authority</xsl:text></xsl:attribute>
+		</xsl:if>
+		<a>
+	<xsl:attribute name="href"><xsl:copy-of select="$contextPath"/>/browse?value=<xsl:copy-of select="node()" />&amp;type=author</xsl:attribute>
+	<xsl:copy-of select="node()" />
+	</a>
+
+	</span>
     </xsl:template>
 </xsl:stylesheet>
 

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -1218,14 +1218,17 @@
        </div>
     </xsl:template>
 
+    <xsl:variable name="etal_limit" select="5"/>
     <xsl:template name="authors_with_short_summary_view">
 	<xsl:param name="contextPath"/>
+	<xsl:variable name="authors_count" select="count(dim:field[@element='contributor'][@qualifier='author' or @qualifier='other'])"/>
 	<xsl:choose>
-		<xsl:when test="count(dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']) &gt; 3">
+		<xsl:when test="$authors_count &gt; $etal_limit">
 			<details>
 				<summary>
-
-					<xsl:for-each select="dim:field[@element='contributor'][@qualifier='author' or @qualifier='other'][position() &lt;= 3]">
+					<!-- APA 6+: A; et al. -->
+					<!-- this selects just the first author; it's a for-each loop to set a context for the print_author template -->
+					<xsl:for-each select="dim:field[@element='contributor'][@qualifier='author' or @qualifier='other'][position() = 1]">
 						<xsl:call-template name="print_author">
 							<xsl:with-param name="contextPath" select="$contextPath"/>
 						</xsl:call-template>
@@ -1240,11 +1243,28 @@
 			</details>
 		</xsl:when>
 		<xsl:otherwise>
-			<xsl:call-template name="print_all_authors">
+			<xsl:call-template name="few_authors_formatted">
 				<xsl:with-param name="contextPath" select="$contextPath"/>
 			</xsl:call-template>
 		</xsl:otherwise>
 	</xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="few_authors_formatted">
+    	<xsl:param name="contextPath"/>
+	<xsl:for-each select="dim:field[@element='contributor'][@qualifier='author' or @qualifier='other'][position() &lt;= $etal_limit]">
+		<xsl:call-template name="print_author">
+			<xsl:with-param name="contextPath" select="$contextPath"/>
+		</xsl:call-template>
+		<xsl:choose>
+			<xsl:when test="count(following-sibling::dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']) = 1">
+				<xsl:text> and </xsl:text>
+			</xsl:when>
+			<xsl:when test="count(following-sibling::dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']) &gt; 1">
+				<xsl:text>;</xsl:text>
+			</xsl:when>
+		</xsl:choose>
+	</xsl:for-each>
     </xsl:template>
 
     <xsl:template name="print_all_authors">

--- a/dspace-xmlui/src/main/webapp/themes/UFALHome/lib/xsl/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFALHome/lib/xsl/page-structure.xsl
@@ -514,22 +514,7 @@
 			<div class="author">
 				<xsl:choose>
 					<xsl:when test="dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']">
-						<xsl:for-each
-							select="dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']">
-							<span>
-								<xsl:if test="@authority">
-									<xsl:attribute name="class"><xsl:text>ds-dc_contributor_author-authority</xsl:text></xsl:attribute>
-								</xsl:if>
-                                <a>
-									<xsl:attribute name="href"><xsl:copy-of select="$context-path"/>/browse?value=<xsl:copy-of select="node()" />&amp;type=author</xsl:attribute>
-									<xsl:copy-of select="node()" />
-								</a>                                
-							</span>
-							<xsl:if
-								test="count(following-sibling::dim:field[@element='contributor'][@qualifier='author' or @qualifier='other']) != 0">
-								<xsl:text>; </xsl:text>
-							</xsl:if>
-						</xsl:for-each>
+			    			<xsl:call-template name="authors_with_short_summary_view"/>
 					</xsl:when>
 					<xsl:when test="dim:field[@element='creator']">
 						<xsl:for-each select="dim:field[@element='creator']">

--- a/dspace/config/crosswalks/oai/metadataFormats/html.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/html.xsl
@@ -10,7 +10,7 @@
 
     <!-- repository name -->
     <xsl:variable name="dspace.name" select="confman:getProperty('dspace.name')"/>
-    <xsl:variable name="authorsLimitLT" select="4"/>
+    <xsl:variable name="authorsLimitLT" select="6"/>
 
     <xsl:output omit-xml-declaration="yes" method="xml" indent="yes" cdata-section-elements="h:html"/>
 
@@ -81,14 +81,17 @@
                    If you decide to change it test it well.
                 -->
                 <xsl:if test="position() &lt; $authorsLimitLT">
+                  <xsl:if test="position() = 1 or $authorsCount &lt; $authorsLimitLT">
                     <xsl:value-of select="."/>
                     <xsl:choose>
                         <!-- if `$authorsLimitLT - 1` or less authors use 'and' before the last name -->
-                        <xsl:when test="position() > 0 and position() = last()-1 and $authorsCount &lt; $authorsLimitLT"> and </xsl:when>
+
+                        <xsl:when test="position() = last()-1 and $authorsCount &lt; $authorsLimitLT"> and </xsl:when>
                         <xsl:when test="position() &lt; last() and position() &lt; $authorsLimitLT - 1">; </xsl:when>
                     </xsl:choose>
-                    <!-- last position and more authors than we display, add 'et al.', eg. 3rd author and the max displayed is 3 -->
-                    <xsl:if test="position() > 0 and position() = $authorsLimitLT - 1 and $authorsCount &gt; $authorsLimitLT - 1">; et al.</xsl:if>
+                  </xsl:if>
+                  <!-- last position and more authors than we display, add 'et al.', eg. 3rd author and the max displayed is 3 -->
+                  <xsl:if test="position() = $authorsLimitLT - 1 and $authorsCount &gt; $authorsLimitLT - 1">et al.</xsl:if>
                 </xsl:if>
             </xsl:for-each>
         </xsl:if>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -3248,6 +3248,7 @@
 	<message key="xmlui.UFAL.artifactbrowser.item_view.licensed_under">Licenční kategorie: {0} <br/>Licence: </message>
 	<message key="xmlui.UFAL.artifactbrowser.item_view.preview">Náhled</message>
 	<message key="xmlui.UFAL.artifactbrowser.item_view.file_preview">Náhled souboru</message>
+        <message key="xmlui.UFAL.artifactbrowser.item_view.show_all_authors">zobraz všechny autory</message>
 
 	<!-- DisplayShareLink -->
 	<message key="xmlui.aspect.submission.submit.DisplayShareLink.title">Sdílet odkaz</message>


### PR DESCRIPTION
resolves #956 
the summary is first 3 authors + et al + toggle to display all authors.
All authors include the three authors shown in summary.
When there are 3 or less authors the view is as it used to be.

This changes item-view, item-list (search result) and
UFALHome/**/pat-structure (top/recent on first page).

![image](https://user-images.githubusercontent.com/1842385/118484764-e213a080-b717-11eb-8fb1-ff5c789bd879.png)

![image](https://user-images.githubusercontent.com/1842385/118484829-f22b8000-b717-11eb-9f7b-9ae79c7af9dc.png)

![image](https://user-images.githubusercontent.com/1842385/118484968-1f782e00-b718-11eb-8c49-a6dc26c340a7.png)

![image](https://user-images.githubusercontent.com/1842385/118485021-2d2db380-b718-11eb-8095-f548bd4a2dca.png)
