### PR TITLE
Curation fixes

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ItemMetadataQAChecker.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ItemMetadataQAChecker.java
@@ -31,6 +31,7 @@ import org.dspace.handle.HandleManager;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.dspace.utils.DSpace;
 
 import static cz.cuni.mff.ufal.curation.RequiredMetadata.addMagicString;
 
@@ -43,8 +44,8 @@ public class ItemMetadataQAChecker extends AbstractCurationTask {
 
     public static final int CURATE_WARNING = -1000;
     /** Expected types. */
-    private static final String[] DCTYPE_VALUES = { 
-        "corpus", "lexicalConceptualResource", "languageDescription", "toolService" };
+    private static final String[] DCTYPE_VALUES = new DSpace().getConfigurationService().getPropertyAsType("lr.curation.metadata.expected.types" ,
+            new String[]{ "corpus", "lexicalConceptualResource", "languageDescription", "toolService" });
     private static final Set<String> DCTYPE_VALUES_SET = new HashSet<String>(
         Arrays.asList(DCTYPE_VALUES));
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ItemMetadataQAChecker.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ItemMetadataQAChecker.java
@@ -41,6 +41,8 @@ public class ItemMetadataQAChecker extends AbstractCurationTask {
     private static final Set<String> DCTYPE_VALUES_SET = new HashSet<String>(
         Arrays.asList(DCTYPE_VALUES));
 
+    private static final String[] rightsMdStrings = {"dc.rights.uri", "dc.rights.label", "dc.rights"};
+
     private Map<String, String> _item_titles;
     private String _handle_prefix;
 
@@ -140,6 +142,8 @@ public class ItemMetadataQAChecker extends AbstractCurationTask {
                         validate_branding_consistency(item, dcs, results);
                         //
                         validate_rights_labels(item, dcs, results);
+                        //
+                        item_with_files_has_license(item);
                         //
                         validate_highly_recommended_metadata(item, dcs, results);
                         //
@@ -468,6 +472,29 @@ public class ItemMetadataQAChecker extends AbstractCurationTask {
 			}
 		}
 	}
+
+	private void item_with_files_has_license(Item item) throws CurateException {
+        try {
+            boolean fail = false;
+            StringBuilder sb = new StringBuilder();
+            if (item.getNonInternalBitstreams().length > 0) {
+                for(String mdString : rightsMdStrings){
+                    final Metadatum[] vals = item.getMetadataByMetadataString(mdString);
+                    if(vals == null || vals.length == 0){
+                        fail = true;
+                        sb.append(mdString).append(", ");
+                    }
+                }
+            }
+            if(fail){
+                throw new CurateException("There are bitsreams but incomplete rights metadata. Missing: " + sb.toString(), Curator.CURATE_FAIL);
+            }
+        } catch (SQLException throwables) {
+            throw  new CurateException(throwables.getMessage(), Curator.CURATE_ERROR);
+        }
+
+
+    }
 
 } // class ItemMetadataQAChecker
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/RewriteRightsMetadata.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/RewriteRightsMetadata.java
@@ -14,7 +14,7 @@ import cz.cuni.mff.ufal.DSpaceApi;
 import cz.cuni.mff.ufal.lindat.utilities.hibernate.LicenseDefinition;
 import cz.cuni.mff.ufal.lindat.utilities.interfaces.IFunctionalities;
 
-public class AddLabelMetadata extends AbstractCurationTask {
+public class RewriteRightsMetadata extends AbstractCurationTask {
 
     private int status = Curator.CURATE_UNSET;
 
@@ -48,6 +48,9 @@ public class AddLabelMetadata extends AbstractCurationTask {
 	            if(license!=null) {                        
 	            	item.clearMetadata("dc", "rights", "label", Item.ANY);
 	            	item.addMetadata("dc", "rights", "label", Item.ANY, license.getLicenseLabel().getLabel());
+	            	// null qualifier means unqualified
+	            	item.clearMetadata("dc", "rights", null, Item.ANY);
+	            	item.addMetadata("dc", "rights", null, Item.ANY, license.getName());
 	            	item.update();
 	            }
 	        	status = Curator.CURATE_SUCCESS;

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -23,7 +23,8 @@ plugin.named.org.dspace.curate.CurationTask = \
     cz.cuni.mff.ufal.curation.FixOpenAIREMetadata = fixopenaire, \
     cz.cuni.mff.ufal.curation.FastLinkChecker = fastchecklinks, \
     cz.cuni.mff.ufal.curation.ProcessBitstreams = processbitstreams, \
-    cz.cuni.mff.ufal.curation.DepositLicenseCheck = depositlicense
+    cz.cuni.mff.ufal.curation.DepositLicenseCheck = depositlicense, \
+    cz.cuni.mff.ufal.curation.RewriteRightsMetadata = rewriterightsmetadata
 # add new tasks here
 
 ## task queue implementation

--- a/dspace/config/modules/lr.cfg
+++ b/dspace/config/modules/lr.cfg
@@ -235,6 +235,9 @@ ${tracker.disabled.collection}
 # Leave it empty if you want to check everything.
 lr.curation.metadata.checkrequired.ignore = ${lr.curation.metadata.checkrequired.ignore}
 
+# ItemMetadataQAChecker
+${curation.metadata.expected.types}
+
 ############################################
 #
 # Link checker


### PR DESCRIPTION
- expected types are configurable
- different way to check for validity of iso lang codes
- QA now reports missing `dc.rights.uri`, `dc.rights.label` and `dc.rights`. There is a task to add the latter two if the first is present