### PR TITLE
Check for bitstreams in ORIGINAL bundle only

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ItemMetadataQAChecker.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ItemMetadataQAChecker.java
@@ -477,7 +477,7 @@ public class ItemMetadataQAChecker extends AbstractCurationTask {
         try {
             boolean fail = false;
             StringBuilder sb = new StringBuilder();
-            if (item.getNonInternalBitstreams().length > 0) {
+            if (item.hasUploadedFiles()) {
                 for(String mdString : rightsMdStrings){
                     final Metadatum[] vals = item.getMetadataByMetadataString(mdString);
                     if(vals == null || vals.length == 0){


### PR DESCRIPTION
Fix for https://github.com/ufal/clarin-dspace/issues/999.
Tested with metadata quality curation check, not sure if this is enough.