### PR TITLE
display local.approximateDate.issued instead of dc.date.issued

### DIFF
--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -2974,6 +2974,9 @@
   <message key="xmlui.UFAL.artifactbrowser.item_view.preview">Preview</message>
   <message key="xmlui.UFAL.artifactbrowser.item_view.file_preview">File Preview</message>
   <message key="xmlui.UFAL.artifactbrowser.item_view.show_all_authors">show everyone</message>
+  <message key="xmlui.UFAL.artifactbrowser.item_view.date_unknown">The exact date is unknown ({0})</message>
+  <message key="xmlui.UFAL.artifactbrowser.item_view.date_list">This item is composed of parts issued in {0}</message>
+
 
 
 

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-list.xsl
@@ -261,8 +261,8 @@
 	             </xsl:for-each>
 	             <xsl:text> / </xsl:text>
              </xsl:if>
-             <span class="date">	             				
-				<xsl:value-of select="substring(dim:field[@element='date' and @qualifier='issued']/node(),1,10)"/>						            
+             <span class="date">
+                 <xsl:call-template name="date_issued_formatted_value"/>
 			</span>
              <xsl:text>)</xsl:text>
          </div>

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -348,13 +348,7 @@
 						<i18n:text>xmlui.dri2xhtml.METS-1.0.item-date</i18n:text>
 					</dt>
 					<dd>
-						<xsl:for-each select="dim:field[@element='date' and @qualifier='issued']">							
-							<xsl:copy-of select="substring(./node(),1,10)" />
-							<xsl:if
-								test="count(following-sibling::dim:field[@element='date' and @qualifier='issued']) != 0">
-								<br />
-							</xsl:if>
-						</xsl:for-each>
+						<xsl:call-template name="date_issued_formatted_value"/>
 					</dd>
 				</dl>
 				<xsl:call-template name="itemSummaryView-DIM-fields">
@@ -1300,5 +1294,26 @@
 
 	</span>
     </xsl:template>
+
+	<xsl:template name="date_issued_formatted_value">
+		<xsl:variable name="date" select="substring(./dim:field[@element='date' and @qualifier='issued'],1,10)"/>
+		<xsl:choose>
+			<xsl:when test="contains(dim:field[@mdschema='local' and @element='approximateDate' and @qualifier='issued'], ',')">
+				<i18n:translate>
+					<i18n:text>xmlui.UFAL.artifactbrowser.item_view.date_list</i18n:text>
+					<i18n:param><xsl:value-of select="dim:field[@mdschema='local' and @element='approximateDate' and @qualifier='issued']"/></i18n:param>
+				</i18n:translate>
+			</xsl:when>
+			<xsl:when test="dim:field[@mdschema='local' and @element='approximateDate' and @qualifier='issued']">
+				<i18n:translate>
+					<i18n:text>xmlui.UFAL.artifactbrowser.item_view.date_unknown</i18n:text>
+					<i18n:param><xsl:value-of select="dim:field[@mdschema='local' and @element='approximateDate' and @qualifier='issued']"/></i18n:param>
+				</i18n:translate>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="$date" />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
 </xsl:stylesheet>
 

--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -136,6 +136,12 @@
         <scope_note>Where the data comes from, and who to attribute. Filled in especially when different
             from dc.publisher</scope_note>
     </dc-type>
+    <dc-type>
+        <schema>local</schema>
+        <element>approximateDate</element>
+        <qualifier>issued</qualifier>
+        <scope_note>Date issued used where the point in time is uncertain; eg. a range.</scope_note>
+    </dc-type>
 </dspace-dc-types>
 
 

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -3249,6 +3249,8 @@
 	<message key="xmlui.UFAL.artifactbrowser.item_view.preview">Náhled</message>
 	<message key="xmlui.UFAL.artifactbrowser.item_view.file_preview">Náhled souboru</message>
         <message key="xmlui.UFAL.artifactbrowser.item_view.show_all_authors">zobraz všechny autory</message>
+	<message key="xmlui.UFAL.artifactbrowser.item_view.date_unknown">Přesné datum není známo ({0})</message>
+	<message key="xmlui.UFAL.artifactbrowser.item_view.date_list">Tato položka je složena z částí vydaných v letech {0}</message>
 
 	<!-- DisplayShareLink -->
 	<message key="xmlui.aspect.submission.submit.DisplayShareLink.title">Sdílet odkaz</message>


### PR DESCRIPTION
approximateDate is currently either "circa range" (eg. "cca 1920-1949")
or a list of years (each an issue date of a part).
dc.date.issued is either 0000 (unknown) or one of the years listed in
approximate.
This is display only and only in item-view/item-list. The 0000 will be shown in
refbox if you don't use other measures (such as local.refbox.format).

dc.date.issued is not expected to be repeatable; removed the for-each in
item-view.

You need to:
```
bin/dspace registry-loader -metadata .../dspace/config/registries/local-types.xml
```