### PR TITLE
Fix typo

### DIFF
--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -3164,7 +3164,7 @@
 	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.wordnet">wordnet</message>
 	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.thesaurus">thesaurus</message>
 	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.framenet">framenet</message>
-	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.terminilogicalResource">terminilogicalResource</message>
+	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.terminologicalResource">terminologicalResource</message>
 	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.machineReadableDictionary">machineReadableDictionary</message>
 	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.lexicon">lexicon</message>
 	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.other">other</message>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -1039,8 +1039,8 @@
                 <stored-value>framenet</stored-value>
             </pair>
             <pair>
-                <displayed-value>input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.terminilogicalResource</displayed-value>
-                <stored-value>terminilogicalResource</stored-value>
+                <displayed-value>input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.terminologicalResource</displayed-value>
+                <stored-value>terminologicalResource</stored-value>
             </pair>
             <pair>
                 <displayed-value>input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.machineReadableDictionary</displayed-value>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -3423,7 +3423,7 @@
 	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.wordnet">wordnet</message>
 	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.thesaurus">thesaurus</message>
 	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.framenet">framenet</message>
-	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.terminilogicalResource">terminilogicalResource</message>
+	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.terminologicalResource">terminologicalResource</message>
 	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.machineReadableDictionary">machineReadableDictionary</message>
 	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.lexicon">lexicon</message>
 	<message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.other">other</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_sl.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_sl.xml
@@ -3044,7 +3044,7 @@ Google Analytics Statistics Aspect
   <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.wordnet">wordnet</message>
   <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.thesaurus">tezaver</message>
   <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.framenet">framenet</message>
-  <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.terminilogicalResource">terminološkiVir</message>
+  <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.terminologicalResource">terminološkiVir</message>
   <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.machineReadableDictionary">strojnoBerljivSlovar</message>
   <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.lexicon">slovar</message>
   <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.other">drugo</message>

--- a/utilities/project_helpers/bits/messages.template
+++ b/utilities/project_helpers/bits/messages.template
@@ -2997,7 +2997,7 @@
   <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.wordnet">wordnet</message>
   <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.thesaurus">thesaurus</message>
   <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.framenet">framenet</message>
-  <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.terminilogicalResource">terminilogicalResource</message>
+  <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.terminologicalResource">terminologicalResource</message>
   <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.machineReadableDictionary">machineReadableDictionary</message>
   <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.lexicon">lexicon</message>
   <message key="input_forms.value_pairs.metashare_detailed_lexicalConceptualResource.other">other</message>


### PR DESCRIPTION
terminilogicalResource -> terminologicalResource
This showed up during elg harvest.
Note: this fixes the issue for newly created resources. The existing
need to be updated manually.

To do that go to control panel -> metadata quality ('/xmlui/admin/panel?tab=Metadata%20Quality') select "metashare.ResourceInfo#ContentInfo.detailedType" and click "Show metadata values" in the "Occurrences in items" section find the offending value (`terminilogicalResource`), correct it and click "Update all occurrences"