### PR TITLE
Licensing issue

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/runnable/CheckLicenses.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/runnable/CheckLicenses.java
@@ -1,0 +1,84 @@
+package cz.cuni.mff.ufal.dspace.runnable;
+
+import cz.cuni.mff.ufal.DSpaceApi;
+import cz.cuni.mff.ufal.lindat.utilities.HibernateFunctionalityManager;
+import cz.cuni.mff.ufal.lindat.utilities.hibernate.LicenseResourceMapping;
+import cz.cuni.mff.ufal.lindat.utilities.interfaces.IFunctionalities;
+import org.dspace.content.*;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+public class CheckLicenses {
+    static private IFunctionalities f = DSpaceApi.getFunctionalityManager();
+    static private Context ctx = null;
+
+    public static void main(String[] args){
+        f.openSession();
+        try {
+            ctx = new Context();
+            ctx.turnOffAuthorisationSystem();
+            ItemIterator items = Item.findAll(ctx);
+            while (items.hasNext()) {
+                Item item = items.next();
+                checkMetadataAndDatabaseMatch(item);
+            }
+            checkUnexpectedAnonymousConfirmation();
+            ctx.restoreAuthSystemState();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }finally {
+            f.closeSession();
+            if (ctx != null) {
+                ctx.abort();
+            }
+        }
+    }
+
+    private static void checkUnexpectedAnonymousConfirmation() throws SQLException {
+        HibernateFunctionalityManager hf = (HibernateFunctionalityManager)f;
+        List<Integer> bitstreamIdsOfAskOnlyOnceWhereConfirmedByAnonymous = hf.getBitstreamIdsOfAskOnlyOnceWhereConfirmedByAnonymous();
+
+        HashSet<Item> items = new HashSet<Item>();
+        for(int bitstream_id : bitstreamIdsOfAskOnlyOnceWhereConfirmedByAnonymous){
+            Bitstream b =  Bitstream.find(ctx, bitstream_id);
+            if(b == null){
+                System.out.println("ERR: Bitstream " + bitstream_id + " not found");
+            }else{
+                DSpaceObject parentObject = b.getParentObject();
+                if(parentObject.getType() == Constants.ITEM) {
+                    items.add((Item) parentObject);
+                }
+            }
+        }
+        for(Item i :items){
+            System.out.println("ERR: Item " + i.getID() + " has unexpected anonymous confirmation");
+        }
+    }
+
+    private static void checkMetadataAndDatabaseMatch(Item item) throws SQLException {
+        if(item.hasUploadedFiles()){
+            Metadatum[] mds = item.getMetadataByMetadataString("dc.rights.uri");
+            if(mds.length != 1){
+                System.out.println("ERR: Item " + item.getID() + " has " + mds.length + " dc.rights.uri");
+            }else{
+                String uri = mds[0].value;
+                // this should be fine we've checked hasUploadedFiles
+                Bitstream b = item.getNonInternalBitstreams()[0];
+                List<LicenseResourceMapping> mappings = f.getAllMappings(b.getID());
+                for(LicenseResourceMapping mapping : mappings){
+                    if(mapping.isActive()){
+                        if(!uri.equals(mapping.getLicenseDefinition().getDefinition())){
+                            System.out.println("ERR: Item " + item.getID() + " has dc.rights.uri " + uri + " " +
+                                    "but database has " + mapping.getLicenseDefinition().getDefinition());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/utilities/src/main/java/cz/cuni/mff/ufal/lindat/utilities/HibernateFunctionalityManager.java
+++ b/utilities/src/main/java/cz/cuni/mff/ufal/lindat/utilities/HibernateFunctionalityManager.java
@@ -853,7 +853,22 @@ public class HibernateFunctionalityManager implements IFunctionalities {
 		
 		return true;
 	}
-	
+
+	public List<Integer> getBitstreamIdsOfAskOnlyOnceWhereConfirmedByAnonymous(){
+		/**
+		 * This is `select * from license_definition d join license_resource_mapping m on d.license_id = m.license_id
+		 * and d.confirmation = 1 and m.active = true join license_resource_user_allowance al on m.mapping_id = al
+		 * .mapping_id and al.eperson_id = 0;` but in HQL
+		 */
+
+		String query = "select m.bitstreamId FROM LicenseDefinition d"
+				+ " JOIN d.licenseResourceMappings m"
+				+ " JOIN m.licenseResourceUserAllowances al"
+				+ " WHERE d.confirmation=1 AND m.active=true"
+				+ " AND al.userRegistration.epersonId=0";
+		return (List<Integer>)hibernateUtil.findByQuery(query, null);
+	}
+
 	public static void shutdown() {
 		HibernateUtil.getSessionFactory().close();
 	}


### PR DESCRIPTION
The PR contains the following
A check
```
sudo -u tomcat bin/dspace dsrun cz.cuni.mff.ufal.dspace.runnable.CheckLicenses
```
to report possible issues with licenses:
1. for every item with an uploaded file: does `dc.rights.uri` match the active license resource mapping in the utilities database (a mismatch can happen if `dc.rights.uri` is updated manually, outside the licensing framework)
2. items having an "ask only once" license confirmed by the anonymous user

Both reported issues can be fixed by going to the edit item -> license tab, detaching the license, and attaching the (right) license again

A fix in `UFALLicenceAgreementAgreed.java` where an exception is thrown if we are not expecting an anonymous user. The exception blocks the download and no confirmation is entered into the database.
The `AuthorizeException` is wrapped in `RuntimeException` so that it's actually shown to the user.