### PR TITLE
Update to run as dspace user

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -8,14 +8,14 @@
 ARG JDK_VERSION=11
 
 # Step 1 - Run Maven Build
-FROM ufal/dspace-dependencies:dspace-7_x as build
+FROM ufal/dspace-dependencies:dspace-7_x AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install
 RUN mkdir /install \
     && chown -Rv dspace: /install \
     && chown -Rv dspace: /app
-USER dspace
+USER 10001
 # Copy the DSpace source code (from local machine) into the workdir (excluding .dockerignore contents)
 ADD --chown=dspace . /app/
 # Build DSpace.  Copy the dspace-installer directory to /install.  Clean up the build to keep the docker image small
@@ -48,7 +48,10 @@ RUN ant init_installation update_configs update_code
 FROM openjdk:${JDK_VERSION}
 # NOTE: DSPACE_INSTALL must align with the "dspace.dir" default configuration.
 ENV DSPACE_INSTALL=/dspace
+RUN groupadd -g 10002 dspace && \
+    useradd  -u 10001 -g dspace dspace
 # Copy the /dspace directory from 'ant_build' container to /dspace in this container
-COPY --from=ant_build /dspace $DSPACE_INSTALL
+COPY --from=ant_build --chown=10001:10002 /dspace $DSPACE_INSTALL
 # Give java extra memory (1GB)
 ENV JAVA_OPTS=-Xmx1000m
+USER 10001

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -7,13 +7,12 @@
 ARG JDK_VERSION=11
 
 # Step 1 - Run Maven Build
-FROM maven:3-openjdk-${JDK_VERSION}-slim as build
+FROM maven:3-openjdk-${JDK_VERSION}-slim AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # Create the 'dspace' user account & home directory
-RUN useradd dspace \
-    && mkdir -p /home/dspace \
-    && chown -Rv dspace: /home/dspace
+RUN groupadd -g 10002 dspace && \
+    useradd -m  -u 10001 -g dspace dspace
 RUN chown -Rv dspace: /app
 # Need git to support buildnumber-maven-plugin, which lets us know what version of DSpace is being run.
 RUN apt-get update \
@@ -22,10 +21,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch to dspace user & run below commands as that user
-USER dspace
+USER 10001
 
 # Copy the DSpace source code (from local machine) into the workdir (excluding .dockerignore contents)
-ADD --chown=dspace . /app/
+ADD --chown=10001:10002 . /app/
 
 # Trigger the installation of all maven dependencies (hide download progress messages)
 RUN mvn --no-transfer-progress package

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -10,7 +10,7 @@
 ARG JDK_VERSION=11
 
 # Step 1 - Run Maven Build
-FROM ufal/dspace-dependencies:dspace-7_x as build
+FROM ufal/dspace-dependencies:dspace-7_x AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install
@@ -26,8 +26,8 @@ RUN mvn --no-transfer-progress package -Pdspace-rest && \
   mv /app/dspace/target/${TARGET_DIR}/* /install && \
   mvn clean
 
-# Step 2 - Run Ant Deploy
-FROM openjdk:${JDK_VERSION}-slim as ant_build
+# Step 2 - Run Ant Deploy 
+FROM openjdk:${JDK_VERSION}-slim AS ant_build
 ARG TARGET_DIR=dspace-installer
 # COPY the /install directory from 'build' container to /dspace-src in this container
 COPY --from=build /install /dspace-src
@@ -52,8 +52,11 @@ RUN ant init_installation update_configs update_code update_webapps
 FROM tomcat:9-jdk${JDK_VERSION}
 ENV DSPACE_INSTALL=/dspace
 ENV TOMCAT_INSTALL=/usr/local/tomcat
+# Create a custom dspace user with same gid/uid as last stage
+RUN groupadd -g 10002 dspace && \
+    useradd  -u 10001 -g dspace dspace
 # Copy the /dspace directory from 'ant_build' containger to /dspace in this container
-COPY --from=ant_build /dspace $DSPACE_INSTALL
+COPY --from=ant_build --chown=10001:10002 /dspace $DSPACE_INSTALL
 # Enable the AJP connector in Tomcat's server.xml
 # NOTE: secretRequired="false" should only be used when AJP is NOT accessible from an external network. But, secretRequired="true" isn't supported by mod_proxy_ajp until Apache 2.5
 RUN sed -i '/Service name="Catalina".*/a \\n    <Connector protocol="AJP/1.3" port="8009" address="0.0.0.0" redirectPort="8443" URIEncoding="UTF-8" secretRequired="false" />' $TOMCAT_INSTALL/conf/server.xml
@@ -78,5 +81,5 @@ RUN ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/server   &&
 
 # Overwrite the v6.x (deprecated) REST API's web.xml, so that we can run it on HTTP (defaults to requiring HTTPS)
 # WARNING: THIS IS OBVIOUSLY INSECURE. NEVER DO THIS IN PRODUCTION.
-COPY dspace/src/main/docker/test/rest_web.xml $DSPACE_INSTALL/webapps/rest/WEB-INF/web.xml
+COPY --chown=10001:10002 dspace/src/main/docker/test/rest_web.xml $DSPACE_INSTALL/webapps/rest/WEB-INF/web.xml
 RUN sed -i -e "s|\${dspace.dir}|$DSPACE_INSTALL|" $DSPACE_INSTALL/webapps/rest/WEB-INF/web.xml


### PR DESCRIPTION
The current dockerfile for dspace-backend runs the backend as root. The user instruction is not transferred to the last stage, after copying to `FROM tomcat:9-jdk${JDK_VERSION}`.

If i login with `docker exec -it ... /bin/bash` and do 

```
ps aux | grep java
```

I see that the owner of the running process is currently root.

Update dockerfile.depencies
* create with a a specific userid, to reuse across stages
* use -m flag on user-add to create home-folder, instead of mkdir and chown

Update dockerfile
* create dspace user on last stage
* add `USER 10001 # dspace uid` instruction to the last stage
* Fix warning error consistent casing (as->AS, consistent with FROM)

Updated the merge request after attending a workshop with our IT department on kubernetes deployment. We are testing a kubernetes platform https://elastisys.io/compliantkubernetes which has been set up for us.

Some additional changes and their rationale are:

* fixed user id with a number above 10000
a user uid above 10000 was also mentioned during the course. See for example https://github.com/hexops-graveyard/dockerfile?tab=readme-ov-file#do-not-use-a-uid-below-10000

* Using a numeric user to allow the platform to check if the user is actually not running as root
> This means that your Dockerfile uses a non-numeric user and Kubernetes cannot validate whether the image truly runs as non-root.

https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-no-root/
