### PR TITLE
fixes ufal/clarin-dspace#1135

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/clarin/ClarinShibAuthentication.java
@@ -565,7 +565,7 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
 
         // 1) First, look for a netid header.
         if (netidHeaders != null) {
-            eperson = findEpersonByNetId(netidHeaders, shibheaders, eperson, ePersonService, context, true);
+            eperson = findEpersonByNetId(netidHeaders, shibheaders, ePersonService, context, true);
             if (eperson != null) {
                 foundNetID = true;
             }
@@ -1318,7 +1318,7 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
     /**
      * Find an EPerson by a NetID header. The method will go through all the netid headers and try to find a user.
      */
-    public static EPerson findEpersonByNetId(String[] netidHeaders, ShibHeaders shibheaders, EPerson eperson,
+    public static EPerson findEpersonByNetId(String[] netidHeaders, ShibHeaders shibheaders,
                                              EPersonService ePersonService, Context context, boolean logAllowed)
             throws SQLException {
         // Go through all the netid headers and try to find a user. It could be e.g., `eppn`, `persistent-id`,..
@@ -1329,19 +1329,20 @@ public class ClarinShibAuthentication implements AuthenticationMethod {
                 continue;
             }
 
-            eperson = ePersonService.findByNetid(context, netid);
+            EPerson eperson = ePersonService.findByNetid(context, netid);
 
             if (eperson == null && logAllowed) {
                 log.info(
                         "Unable to identify EPerson based upon Shibboleth netid header: '" + netidHeader +
                                 "'='" + netid + "'.");
-            } else {
+            } else if (eperson != null) {
                 log.debug(
                         "Identified EPerson based upon Shibboleth netid header: '" + netidHeader + "'='" +
                                 netid + "'" + ".");
+                return eperson;
             }
         }
-        return eperson;
+        return null;
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/clarin/ClarinShibbolethLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/clarin/ClarinShibbolethLoginFilter.java
@@ -167,7 +167,7 @@ public class ClarinShibbolethLoginFilter extends StatelessLoginFilter {
 
         EPerson ePerson = null;
         try {
-            ePerson = ClarinShibAuthentication.findEpersonByNetId(shib_headers.getNetIdHeaders(), shib_headers, ePerson,
+            ePerson = ClarinShibAuthentication.findEpersonByNetId(shib_headers.getNetIdHeaders(), shib_headers,
                     ePersonService, context, false);
         } catch (SQLException e) {
             // It is logged in the ClarinShibAuthentication class.


### PR DESCRIPTION
fixes ufal/clarin-dspace#1135 - findEpersonByNetId should stop searching when it finds an eperson

- moved the `return eperson` inside the for cycle (after eperson non null check).
- removed the eperson param (both callers were passing in `null`)