### PR TITLE
Issue 1055: fixed security issue for downloading file with non anonymous license

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizationBitstreamUtils.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizationBitstreamUtils.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.authorize;
 
+import static org.dspace.content.clarin.ClarinLicense.Confirmation;
+
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Objects;
@@ -117,10 +119,10 @@ public class AuthorizationBitstreamUtils {
 
         // Bitstream should have only one type of the Clarin license, so we could get first record
         ClarinLicense clarinLicense = Objects.requireNonNull(clarinLicenseResourceMappings.get(0)).getLicense();
-        // 3 - Allow download for anonymous users, but with license confirmation
-        // 0 - License confirmation is not required
-        if (Objects.equals(clarinLicense.getConfirmation(), 3) ||
-                Objects.equals(clarinLicense.getConfirmation(), 0)) {
+        // ALLOW_ANONYMOUS - Allow download for anonymous users, but with license confirmation
+        // NOT_REQUIRED - License confirmation is not required
+        if (clarinLicense.getConfirmation() == Confirmation.ALLOW_ANONYMOUS ||
+                clarinLicense.getConfirmation() == Confirmation.NOT_REQUIRED) {
             return true;
         }
         return false;

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicense.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicense.java
@@ -83,7 +83,7 @@ public class ClarinLicense implements ReloadableEntity<Integer> {
     private String definition = null;
 
     @Column(name = "confirmation")
-    private Integer confirmation = 0;
+    private Confirmation confirmation = Confirmation.NOT_REQUIRED;
 
     @Column(name = "required_info")
     private String requiredInfo = null;
@@ -111,11 +111,11 @@ public class ClarinLicense implements ReloadableEntity<Integer> {
         this.definition = definition;
     }
 
-    public Integer getConfirmation() {
+    public Confirmation getConfirmation() {
         return confirmation;
     }
 
-    public void setConfirmation(Integer confirmation) {
+    public void setConfirmation(Confirmation confirmation) {
         this.confirmation = confirmation;
     }
 
@@ -190,5 +190,25 @@ public class ClarinLicense implements ReloadableEntity<Integer> {
 
     public void setEperson(ClarinUserRegistration eperson) {
         this.eperson = eperson;
+    }
+
+    public enum Confirmation {
+
+        NOT_REQUIRED(0), ASK_ONLY_ONCE(1), ASK_ALWAYS(2), ALLOW_ANONYMOUS(3);
+
+        private final int value;
+
+        Confirmation(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        public static Confirmation getConfirmation(int value) {
+            return Arrays.stream(values()).filter(v -> v.getValue() == value).findFirst().orElse(null);
+        }
+
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicenseResourceMappingServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/ClarinLicenseResourceMappingServiceImpl.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.content.clarin;
 
+import static org.dspace.content.clarin.ClarinLicense.Confirmation;
+
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -202,23 +204,23 @@ public class ClarinLicenseResourceMappingServiceImpl implements ClarinLicenseRes
         }
 
         // Confirmation states:
-        // 0 - Not required
-        // 1 - Ask only once
-        // 2 - Ask always
-        // 3 - Allow anonymous
-        if (Objects.equals(clarinLicenseToAgree.getConfirmation(), 0)) {
+        // NOT_REQUIRED
+        // ASK_ONLY_ONCE
+        // ASK_ALWAYS
+        // ALLOW_ANONYMOUS
+        if (clarinLicenseToAgree.getConfirmation() == Confirmation.NOT_REQUIRED) {
             return null;
         }
 
         switch (clarinLicenseToAgree.getConfirmation()) {
-            case 1:
+            case ASK_ONLY_ONCE:
                 // Ask only once - check if the clarin license required info is filled in by the user
                 if (userFilledInRequiredInfo(context, clarinLicenseResourceMapping, userId)) {
                     return null;
                 }
                 return clarinLicenseToAgree;
-            case 2:
-            case 3:
+            case ASK_ALWAYS:
+            case ALLOW_ANONYMOUS:
                 return clarinLicenseToAgree;
             default:
                 return null;

--- a/dspace-api/src/test/java/org/dspace/content/BundleClarinTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BundleClarinTest.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.content;
 
+import static org.dspace.content.clarin.ClarinLicense.Confirmation;
 import static org.dspace.core.Constants.CONTENT_BUNDLE_NAME;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -119,7 +120,7 @@ public class BundleClarinTest extends AbstractDSpaceObjectTest {
             this.clarinLicense.setLicenseLabels(cllSet);
             this.clarinLicense.setName(LICENSE_NAME);
             this.clarinLicense.setDefinition(LICENSE_URI);
-            this.clarinLicense.setConfirmation(0);
+            this.clarinLicense.setConfirmation(Confirmation.NOT_REQUIRED);
             this.clarinLicenseService.update(context, this.clarinLicense);
 
             // initialize second clarin license and clarin license label
@@ -139,7 +140,7 @@ public class BundleClarinTest extends AbstractDSpaceObjectTest {
             this.secondClarinLicense.setLicenseLabels(secondCllSet);
             this.secondClarinLicense.setName("wrong name");
             this.secondClarinLicense.setDefinition("wrong uri");
-            this.secondClarinLicense.setConfirmation(0);
+            this.secondClarinLicense.setConfirmation(Confirmation.NOT_REQUIRED);
             this.clarinLicenseService.update(context, this.secondClarinLicense);
 
             //we need to commit the changes, so we don't block the table for testing

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ClarinLicenseConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ClarinLicenseConverter.java
@@ -41,7 +41,7 @@ public class ClarinLicenseConverter implements DSpaceConverter<ClarinLicense, Cl
         license.setProjection(projection);
         license.setId(modelObject.getID());
         license.setName(modelObject.getName());
-        license.setConfirmation(modelObject.getConfirmation());
+        license.setConfirmation(modelObject.getConfirmation().getValue());
         license.setDefinition(modelObject.getDefinition());
         license.setRequiredInfo(modelObject.getRequiredInfo());
         setExtendedClarinLicenseLabels(license, modelObject.getLicenseLabels(), projection);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinLicenseRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinLicenseRestRepository.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.repository;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.dspace.content.clarin.ClarinLicense.Confirmation;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -172,7 +173,7 @@ public class ClarinLicenseRestRepository extends DSpaceRestRepository<ClarinLice
         clarinLicense.setLicenseLabels(this.getClarinLicenseLabels(clarinLicenseRest.getClarinLicenseLabel(),
                 clarinLicenseRest.getExtendedClarinLicenseLabels()));
         clarinLicense.setDefinition(clarinLicenseRest.getDefinition());
-        clarinLicense.setConfirmation(clarinLicenseRest.getConfirmation());
+        clarinLicense.setConfirmation(Confirmation.getConfirmation(clarinLicenseRest.getConfirmation()));
         clarinLicense.setRequiredInfo(clarinLicenseRest.getRequiredInfo());
         clarinLicense.setEperson(userRegistration);
 
@@ -220,7 +221,7 @@ public class ClarinLicenseRestRepository extends DSpaceRestRepository<ClarinLice
         clarinLicense.setName(clarinLicenseRest.getName());
         clarinLicense.setRequiredInfo(clarinLicenseRest.getRequiredInfo());
         clarinLicense.setDefinition(clarinLicenseRest.getDefinition());
-        clarinLicense.setConfirmation(clarinLicenseRest.getConfirmation());
+        clarinLicense.setConfirmation(Confirmation.getConfirmation(clarinLicenseRest.getConfirmation()));
         clarinLicense.setLicenseLabels(this.getClarinLicenseLabels(clarinLicenseRest.getClarinLicenseLabel(),
                 clarinLicenseRest.getExtendedClarinLicenseLabels()));
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestControllerIT.java
@@ -126,7 +126,8 @@ public class AuthorizationRestControllerIT extends AbstractControllerIntegration
                 .withDspaceObject(bitstream).build();
 
         // Create clarin license with clarin license label
-        clarinLicense = createClarinLicense(CLARIN_LICENSE_NAME, "Test Def", "Test R Info", 3);
+        clarinLicense = createClarinLicense(CLARIN_LICENSE_NAME, "Test Def", "Test R Info",
+                ClarinLicense.Confirmation.ALLOW_ANONYMOUS);
         context.restoreAuthSystemState();
     }
 
@@ -321,7 +322,8 @@ public class AuthorizationRestControllerIT extends AbstractControllerIntegration
     /**
      * Create ClarinLicense object with ClarinLicenseLabel object for testing purposes.
      */
-    private ClarinLicense createClarinLicense(String name, String definition, String requiredInfo, int confirmation)
+    private ClarinLicense createClarinLicense(String name, String definition, String requiredInfo,
+                                              ClarinLicense.Confirmation confirmation)
             throws SQLException, AuthorizeException {
         ClarinLicense clarinLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
         clarinLicense.setConfirmation(confirmation);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinLicenseImportControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinLicenseImportControllerIT.java
@@ -82,7 +82,7 @@ public class ClarinLicenseImportControllerIT extends AbstractControllerIntegrati
         // create ClarinLicenses
         firstCLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
         firstCLicense.setName("CL Name1");
-        firstCLicense.setConfirmation(0);
+        firstCLicense.setConfirmation(ClarinLicense.Confirmation.NOT_REQUIRED);
         firstCLicense.setDefinition("CL Definition1");
         firstCLicense.setRequiredInfo("CL Req1");
         // add ClarinLicenseLabels to the ClarinLicense

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinLicenseRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinLicenseRestRepositoryIT.java
@@ -110,7 +110,7 @@ public class ClarinLicenseRestRepositoryIT extends AbstractControllerIntegration
         // create ClarinLicenses
         firstCLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
         firstCLicense.setName("CL Name1");
-        firstCLicense.setConfirmation(0);
+        firstCLicense.setConfirmation(ClarinLicense.Confirmation.NOT_REQUIRED);
         firstCLicense.setDefinition("CL Definition1");
         firstCLicense.setRequiredInfo("CL Req1");
         // add ClarinLicenseLabels to the ClarinLicense
@@ -123,7 +123,7 @@ public class ClarinLicenseRestRepositoryIT extends AbstractControllerIntegration
 
         secondCLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
         secondCLicense.setName("CL Name2");
-        secondCLicense.setConfirmation(1);
+        secondCLicense.setConfirmation(ClarinLicense.Confirmation.ASK_ONLY_ONCE);
         secondCLicense.setDefinition("CL Definition2");
         secondCLicense.setRequiredInfo("CL Req2");
         // add ClarinLicenseLabels to the ClarinLicense
@@ -328,7 +328,7 @@ public class ClarinLicenseRestRepositoryIT extends AbstractControllerIntegration
         ClarinLicense clarinLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
         clarinLicense.setName("default name");
         clarinLicense.setDefinition("default definition");
-        clarinLicense.setConfirmation(0);
+        clarinLicense.setConfirmation(ClarinLicense.Confirmation.NOT_REQUIRED);
         clarinLicense.setRequiredInfo("default info");
 
         Set<ClarinLicenseLabel> clarinLicenseLabels = new HashSet<>();
@@ -340,7 +340,7 @@ public class ClarinLicenseRestRepositoryIT extends AbstractControllerIntegration
         ClarinLicense clarinLicenseUpdated = ClarinLicenseBuilder.createClarinLicense(context).build();
         clarinLicenseUpdated.setName("updated name");
         clarinLicenseUpdated.setDefinition("updated definition");
-        clarinLicenseUpdated.setConfirmation(4);
+        clarinLicenseUpdated.setConfirmation(null);
         clarinLicenseUpdated.setRequiredInfo("updated info");
 
         Set<ClarinLicenseLabel> clarinLicenseLabelUpdated = new HashSet<>();
@@ -376,7 +376,7 @@ public class ClarinLicenseRestRepositoryIT extends AbstractControllerIntegration
 
         clarinLicense.setName("default name");
         clarinLicense.setDefinition("default definition");
-        clarinLicense.setConfirmation(0);
+        clarinLicense.setConfirmation(ClarinLicense.Confirmation.NOT_REQUIRED);
         clarinLicense.setRequiredInfo("default info");
 
         Set<ClarinLicenseLabel> clarinLicenseLabels = new HashSet<>();
@@ -403,7 +403,7 @@ public class ClarinLicenseRestRepositoryIT extends AbstractControllerIntegration
 
         clarinLicense.setName("default name");
         clarinLicense.setDefinition("default definition");
-        clarinLicense.setConfirmation(0);
+        clarinLicense.setConfirmation(ClarinLicense.Confirmation.NOT_REQUIRED);
         clarinLicense.setRequiredInfo("default info");
 
         Set<ClarinLicenseLabel> clarinLicenseLabels = new HashSet<>();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataImportControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataImportControllerIT.java
@@ -89,7 +89,8 @@ public class ClarinUserMetadataImportControllerIT extends AbstractEntityIntegrat
         String clarinLicenseName = "Test Clarin License";
 
         // 2. Create clarin license with clarin license label
-        clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", requiredInfo, 0);
+        clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", requiredInfo,
+                ClarinLicense.Confirmation.NOT_REQUIRED);
 
         // creating replace operation
         Map<String, String> licenseReplaceOpValue = new HashMap<String, String>();
@@ -316,7 +317,8 @@ public class ClarinUserMetadataImportControllerIT extends AbstractEntityIntegrat
     /**
      * Create ClarinLicense object with ClarinLicenseLabel object for testing purposes.
      */
-    private ClarinLicense createClarinLicense(String name, String definition, String requiredInfo, int confirmation)
+    private ClarinLicense createClarinLicense(String name, String definition, String requiredInfo,
+                                              ClarinLicense.Confirmation confirmation)
             throws SQLException, AuthorizeException {
         ClarinLicense clarinLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
         clarinLicense.setConfirmation(confirmation);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest;
 
 import static org.dspace.app.rest.repository.ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE;
 import static org.dspace.app.rest.repository.ClarinUserMetadataRestController.CHECK_EMAIL_RESPONSE_CONTENT;
+import static org.dspace.content.clarin.ClarinLicense.Confirmation;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -72,7 +73,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
     Bitstream bitstream2;
 
     // Attach ClarinLicense to the Bitstream
-    private void prepareEnvironment(String requiredInfo, Integer confirmation) throws Exception {
+    private void prepareEnvironment(String requiredInfo, Confirmation confirmation) throws Exception {
         // 1. Create Workspace Item with uploaded file
         // 2. Create Clarin License
         // 3. Send request to add Clarin License to the Workspace Item
@@ -126,7 +127,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
 
     @Test
     public void notAuthorizedUser_shouldReturnToken() throws Exception {
-        this.prepareEnvironment("NAME", 0);
+        this.prepareEnvironment("NAME", Confirmation.NOT_REQUIRED);
         ObjectMapper mapper = new ObjectMapper();
         ClarinUserMetadataRest clarinUserMetadata1 = new ClarinUserMetadataRest();
         clarinUserMetadata1.setMetadataKey("NAME");
@@ -158,7 +159,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
 
     @Test
     public void notAuthorizedUser_shouldSendEmail() throws Exception {
-        this.prepareEnvironment("SEND_TOKEN", 0);
+        this.prepareEnvironment("SEND_TOKEN", Confirmation.NOT_REQUIRED);
         ObjectMapper mapper = new ObjectMapper();
         ClarinUserMetadataRest clarinUserMetadata1 = new ClarinUserMetadataRest();
         clarinUserMetadata1.setMetadataKey("NAME");
@@ -199,7 +200,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
 
     @Test
     public void authorizedUserWithoutMetadata_shouldReturnToken() throws Exception {
-        this.prepareEnvironment("NAME", 0);
+        this.prepareEnvironment("NAME", Confirmation.NOT_REQUIRED);
         context.turnOffAuthorisationSystem();
         ClarinUserRegistration clarinUserRegistration = ClarinUserRegistrationBuilder
                 .createClarinUserRegistration(context).withEPersonID(admin.getID()).build();
@@ -244,7 +245,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
 
     @Test
     public void authorizedUserWithoutMetadata_shouldSendEmail() throws Exception {
-        this.prepareEnvironment("SEND_TOKEN", 0);
+        this.prepareEnvironment("SEND_TOKEN", Confirmation.NOT_REQUIRED);
         context.turnOffAuthorisationSystem();
         ClarinUserRegistration clarinUserRegistration = ClarinUserRegistrationBuilder
                 .createClarinUserRegistration(context).withEPersonID(admin.getID()).build();
@@ -298,7 +299,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
 
     @Test
     public void authorizedUserWithMetadata_shouldSendToken() throws Exception {
-        this.prepareEnvironment("NAME,ADDRESS", 0);
+        this.prepareEnvironment("NAME,ADDRESS", Confirmation.NOT_REQUIRED);
         context.turnOffAuthorisationSystem();
         ClarinUserRegistration clarinUserRegistration = ClarinUserRegistrationBuilder
                 .createClarinUserRegistration(context).withEPersonID(admin.getID()).build();
@@ -347,7 +348,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
 
     @Test
     public void authorizedUserWithMetadata_shouldSendEmail() throws Exception {
-        this.prepareEnvironment("SEND_TOKEN,NAME,ADDRESS", 0);
+        this.prepareEnvironment("SEND_TOKEN,NAME,ADDRESS", Confirmation.NOT_REQUIRED);
         context.turnOffAuthorisationSystem();
         ClarinUserRegistration clarinUserRegistration = ClarinUserRegistrationBuilder
                 .createClarinUserRegistration(context).withEPersonID(admin.getID()).build();
@@ -406,7 +407,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
     // Confirmation = 1
     @Test
     public void authorizedUserWithoutMetadata_shouldDownloadToken() throws Exception {
-        this.prepareEnvironment(null, 1);
+        this.prepareEnvironment(null, Confirmation.ASK_ONLY_ONCE);
         context.turnOffAuthorisationSystem();
         ClarinUserRegistration clarinUserRegistration = ClarinUserRegistrationBuilder
                 .createClarinUserRegistration(context).withEPersonID(admin.getID()).build();
@@ -440,7 +441,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
     public void shouldNotCreateDuplicateUserMetadataBasedOnHistory() throws Exception {
         // Prepare environment with Clarin License, resource mapping, allowance, user registration and user metadata
         // then try to download the same bitstream again and the user metadata should not be created based on history
-        this.prepareEnvironment("NAME,ADDRESS", 0);
+        this.prepareEnvironment("NAME,ADDRESS", Confirmation.NOT_REQUIRED);
         context.turnOffAuthorisationSystem();
         ClarinUserRegistration clarinUserRegistration = ClarinUserRegistrationBuilder
                 .createClarinUserRegistration(context).withEPersonID(admin.getID()).build();
@@ -613,7 +614,8 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
     /**
      * Create ClarinLicense object with ClarinLicenseLabel object for testing purposes.
      */
-    private ClarinLicense createClarinLicense(String name, String definition, String requiredInfo, int confirmation)
+    private ClarinLicense createClarinLicense(String name, String definition, String requiredInfo,
+                                              Confirmation confirmation)
             throws SQLException, AuthorizeException {
         ClarinLicense clarinLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
         clarinLicense.setConfirmation(confirmation);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkspaceItemRestRepositoryIT.java
@@ -625,7 +625,8 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
         String clarinLicenseName = "Test Clarin License";
 
         // 2. Create clarin license with clarin license label
-        ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info", 0);
+        ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info",
+                ClarinLicense.Confirmation.NOT_REQUIRED);
 
         // creating replace operation
         Map<String, String> licenseReplaceOpValue = new HashMap<String, String>();
@@ -676,7 +677,8 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
         List<Operation> replaceOperations = new ArrayList<Operation>();
         // 2. Create Clarin License
         String clarinLicenseName = "Test Clarin License";
-        ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info", 0);
+        ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info",
+                ClarinLicense.Confirmation.NOT_REQUIRED);
         context.restoreAuthSystemState();
 
         // Creating replace operation
@@ -754,9 +756,11 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
         String updateClarinLicenseName = "Updated Clarin License";
 
         // 2. Create Clarin Licenses
-        ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info", 0);
+        ClarinLicense clarinLicense = createClarinLicense(clarinLicenseName, "Test Def", "Test R Info",
+                ClarinLicense.Confirmation.NOT_REQUIRED);
         ClarinLicense updatedClarinLicense =
-                createClarinLicense(updateClarinLicenseName, "Test Def2", "Test R Info2", 0);
+                createClarinLicense(updateClarinLicenseName, "Test Def2", "Test R Info2",
+                        ClarinLicense.Confirmation.NOT_REQUIRED);
         context.restoreAuthSystemState();
 
         // Creating replace operation
@@ -1008,7 +1012,8 @@ public class ClarinWorkspaceItemRestRepositoryIT extends AbstractControllerInteg
     /**
      * Create ClarinLicense object with ClarinLicenseLabel object for testing purposes.
      */
-    private ClarinLicense createClarinLicense(String name, String definition, String requiredInfo, int confirmation)
+    private ClarinLicense createClarinLicense(String name, String definition, String requiredInfo,
+                                              ClarinLicense.Confirmation confirmation)
             throws SQLException, AuthorizeException {
         ClarinLicense clarinLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
         clarinLicense.setConfirmation(confirmation);


### PR DESCRIPTION
Anonymous user was able to download file, related to a license that required  confirmation from non anonymous user.

Fixed, by adding one more check in rest API where the access token is required.

Also changed the ClarinLicense confirmation field type from Integer to enum type (ClarinLicense.Configuration enum).
This required some refactoring.