### PR TITLE
Issue 1157: allow to access File Downloader for any authorized user

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/FileDownloaderConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/administer/FileDownloaderConfiguration.java
@@ -7,8 +7,12 @@
  */
 package org.dspace.administer;
 
+import java.util.List;
+
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
+import org.dspace.core.Context;
+import org.dspace.scripts.DSpaceCommandLineParameter;
 import org.dspace.scripts.configuration.ScriptConfiguration;
 
 public class FileDownloaderConfiguration extends ScriptConfiguration<FileDownloader> {
@@ -33,6 +37,20 @@ public class FileDownloaderConfiguration extends ScriptConfiguration<FileDownloa
     @Override
     public void setDspaceRunnableClass(Class<FileDownloader> dspaceRunnableClass) {
         this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+
+    /**
+     * This script is allowed to execute to any authorized user. Further access control mechanism then checks,
+     * if the current user is authorized to download a file to the item specified in command line parameters.
+     *
+     * @param context   The relevant DSpace context
+     * @param commandLineParameters the parameters that will be used to start the process if known,
+     *        <code>null</code> otherwise
+     * @return          A boolean indicating whether the script is allowed to execute or not
+     */
+    @Override
+    public boolean isAllowedToExecute(Context context, List<DSpaceCommandLineParameter> commandLineParameters) {
+        return true;
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/administer/FileDownloaderIT.java
+++ b/dspace-api/src/test/java/org/dspace/administer/FileDownloaderIT.java
@@ -109,7 +109,7 @@ public class FileDownloaderIT extends AbstractIntegrationTestWithDatabase {
     }
 
     @Test
-    public void testDownloadFileForNotAuthorizedUser() {
+    public void testDownloadFileForAuthorizedUserWithNoPermissionToAddFile() {
         context.setCurrentUser(eperson);
         int port = mockServerRule.getPort();
         String[] args = new String[] {"file-downloader", "-i", item.getID().toString(),

--- a/dspace-api/src/test/java/org/dspace/administer/FileDownloaderIT.java
+++ b/dspace-api/src/test/java/org/dspace/administer/FileDownloaderIT.java
@@ -9,12 +9,14 @@ package org.dspace.administer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 import java.util.List;
 
 import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
@@ -28,7 +30,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockserver.junit.MockServerRule;
-
 
 public class FileDownloaderIT extends AbstractIntegrationTestWithDatabase {
 
@@ -77,7 +78,7 @@ public class FileDownloaderIT extends AbstractIntegrationTestWithDatabase {
 
         int port = mockServerRule.getPort();
         String[] args = new String[]{"file-downloader", "-i", item.getID().toString(),
-                "-u", String.format("http://localhost:%s/test400", port), "-e", "admin@email.com"};
+                "-u", String.format("http://localhost:%s/test400", port), "-e", admin.getEmail()};
         try {
             runDSpaceScript(args);
         } catch (IllegalArgumentException e) {
@@ -96,7 +97,7 @@ public class FileDownloaderIT extends AbstractIntegrationTestWithDatabase {
 
           int port = mockServerRule.getPort();
           String[] args = new String[] {"file-downloader", "-i", item.getID().toString(),
-                  "-u", String.format("http://localhost:%s/test", port), "-e", "admin@email.com"};
+                  "-u", String.format("http://localhost:%s/test", port), "-e", admin.getEmail()};
         runDSpaceScript(args);
 
 
@@ -105,6 +106,15 @@ public class FileDownloaderIT extends AbstractIntegrationTestWithDatabase {
         assertEquals(1, bs.size());
         assertNotNull("Expecting name to be defined", bs.get(0).getName());
 
+    }
+
+    @Test
+    public void testDownloadFileForNotAuthorizedUser() {
+        context.setCurrentUser(eperson);
+        int port = mockServerRule.getPort();
+        String[] args = new String[] {"file-downloader", "-i", item.getID().toString(),
+                "-u", String.format("http://localhost:%s/test", port), "-e", eperson.getEmail()};
+        assertThrows(AuthorizeException.class, () -> runDSpaceScript(args));
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
@@ -129,9 +129,18 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void findAllScriptsGenericLoggedInUserTest() throws Exception {
         String token = getAuthToken(eperson.getEmail(), password);
 
+        ScriptConfiguration<?> fileDownloaderScriptConfiguration =
+                scriptConfigurations.stream()
+                        .filter(scriptConfiguration
+                                -> scriptConfiguration.getName().equals("file-downloader"))
+                        .findAny().orElseThrow();
+
         getClient(token).perform(get("/api/system/scripts"))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.page.totalElements", is(0)));
+                        .andExpect(jsonPath("$.page.totalElements", is(1)))
+                        .andExpect(jsonPath("$._embedded.scripts", Matchers.hasItem(
+                                ScriptMatcher.matchScript(fileDownloaderScriptConfiguration.getName(),
+                                        fileDownloaderScriptConfiguration.getDescription()))));
     }
 
     @Test


### PR DESCRIPTION
We simply expose file downloader to any authorized user.
The check if the user is authorized, is made by
`@PreAuthorize("hasAuthority('AUTHENTICATED')")`
annotation in **ScriptProcesssesController#startProcess** method.

Additional access control mechanism checks if the current user is authorized to ADD a file (specified in command line parameters) to the item's ORIGINAL bundle (item is also specified in command line parameters). 

If authorization fails, the script ends with a failure message like this:
```
2025-04-17 11:46:22.514 INFO file-downloader - 81 @ The script has started
2025-04-17 11:46:25.817 ERROR file-downloader - 81 @ null
2025-04-17 11:46:25.833 ERROR file-downloader - 81 @ org.dspace.authorize.AuthorizeException: Authorization denied for action ADD on BUNDLE:209613c6-1790-4973-8785-7b01584825a2 by user d6d42691-1cdb-4780-88b0-193bfcec347e
	at org.dspace.authorize.AuthorizeServiceImpl.authorizeAction(AuthorizeServiceImpl.java:173)
	at org.dspace.authorize.AuthorizeServiceImpl.authorizeAction(AuthorizeServiceImpl.java:121)
	at org.dspace.authorize.AuthorizeServiceImpl.authorizeAction(AuthorizeServiceImpl.java:115)
	at org.dspace.content.BitstreamServiceImpl.create(BitstreamServiceImpl.java:147)
	at org.dspace.administer.FileDownloader.saveFileToItem(FileDownloader.java:213)
	at org.dspace.administer.FileDownloader.internalRun(FileDownloader.java:179)
	at org.dspace.scripts.DSpaceRunnable.run(DSpaceRunnable.java:150)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

