### PR TITLE
Issue 1200: allow.edit.metadata property should also work for submitters that are members of collection SUBMIT subgroup

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -391,8 +390,7 @@ public class InstallItemServiceImpl implements InstallItemService {
      * @return true if the EPerson is a member (direct or indirect) of a submit group, false otherwise
      */
     private boolean isInSubmitGroup(Context context, EPerson ePerson, Collection collection) throws SQLException {
-        return groupService.isMember(context, ePerson,
-                "COLLECTION_" + collection.getID() + "_SUBMIT");
+        return groupService.isMember(context, ePerson, "COLLECTION_" + collection.getID() + "_SUBMIT");
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
@@ -117,7 +117,7 @@ public class InstallItemServiceImpl implements InstallItemService {
 
         //Allow submitter to edit item
         if (isCollectionAllowedForSubmitterEditing(item.getOwningCollection()) &&
-                isInSubmitGroup(c, item.getSubmitter(), item.getOwningCollection().getID())) {
+                isInSubmitGroup(c, item.getSubmitter(), item.getOwningCollection())) {
             createResourcePolicy(c, item, Constants.WRITE);
         }
 
@@ -386,13 +386,13 @@ public class InstallItemServiceImpl implements InstallItemService {
      * A submit group is identified by the name containing "SUBMIT" and the collection UUID.
      *
      * @param context           The current DSpace context.
-     * @param ePerson           the EPerson that is checked to be member of collection submit group
-     * @param collectionUUID    the UUID of the collection
+     * @param ePerson           the EPerson that is checked to be member of the collection submit group
+     * @param collection        the collection
      * @return true if the EPerson is a member (direct or indirect) of a submit group, false otherwise
      */
-    private boolean isInSubmitGroup(Context context, EPerson ePerson, UUID collectionUUID) throws SQLException {
+    private boolean isInSubmitGroup(Context context, EPerson ePerson, Collection collection) throws SQLException {
         return groupService.isMember(context, ePerson,
-                "COLLECTION_" + collectionUUID.toString() + "_SUBMIT");
+                "COLLECTION_" + collection.getID() + "_SUBMIT");
     }
 
     /**

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -2806,8 +2806,17 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                     .withPassword("dspace")
                     .build();
 
-            Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName(colName)
-                    .withSubmitterGroup(submitter).build();
+            Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName(colName).build();
+
+            // here the submitter(EPerson) is not directly member of the collection SUBMIT group
+            // but member of the "collection-submitters" subgroup that is a child of SUBMIT group
+            Group submitGroup = GroupBuilder.createCollectionSubmitterGroup(context, col1).build();
+
+            GroupBuilder.createGroup(context)
+                    .withParent(submitGroup)
+                    .withName("collection-submitters")
+                    .addMember(submitter)
+                    .build();
 
             context.setCurrentUser(submitter);
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -2808,8 +2808,8 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
 
             Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName(colName).build();
 
-            // here the submitter(EPerson) is not directly member of the collection SUBMIT group
-            // but member of the "collection-submitters" subgroup that is a child of SUBMIT group
+            // here the submitter(EPerson) is not a direct member of the collection SUBMIT group
+            // but member of the "collection-submitters" group that is a subgroup of the SUBMIT group
             Group submitGroup = GroupBuilder.createCollectionSubmitterGroup(context, col1).build();
 
             GroupBuilder.createGroup(context)


### PR DESCRIPTION
Formerly, the **isInSubmitGroup()** method only checked direct members of the collection SUBMIT group.
Now the check is extended to all members - either direct members, or members of a SUBMIT subgroup, etc.