### PR TITLE
Issue 1196: prevent error 500 for non admin user uploading file to bundle 

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -178,7 +178,10 @@ public class AuthorizeServiceImpl implements AuthorizeService {
         // CLARIN
         // This function throws exception if the authorization fails - if it is not reported, the license
         // restrictions are OK
-        if (o.getType() == Constants.BITSTREAM && !isAdmin(c)) {
+        //
+        // the license confirmation is excluded when bitstream is edited,
+        // or when user has admin permission on bitstream object
+        if (o.getType() == Constants.BITSTREAM && action != Constants.WRITE && !isAdmin(c, o)) {
             authorizationBitstreamUtils.authorizeBitstream(c, (Bitstream) o);
         }
         // CLARIN

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -373,6 +373,11 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
         return this;
     }
 
+    public ItemBuilder withLicense(String licenseName, String licenseUri) throws SQLException, AuthorizeException {
+        this.addMetadataValue(item, "dc", "rights", null, licenseName);
+        return this.addMetadataValue(item, "dc", "rights", "uri", licenseUri);
+    }
+
     @Override
     public Item build() {
         try {


### PR DESCRIPTION
Don't force user with ADMIN permission on a bitstream, or with sufficient permissions to accept the license during file upload.