### PR TITLE
The query should be faster like this

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/PreviewContentDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/PreviewContentDAOImpl.java
@@ -42,12 +42,12 @@ public class PreviewContentDAOImpl extends AbstractHibernateDAO<PreviewContent> 
     @Override
     public List<PreviewContent> hasPreview(Context context, Bitstream bitstream) throws SQLException {
         // select only data from the previewcontent table whose ID is not a child in the preview2preview table
-        Query query = createQuery(context,
-                "SELECT pc FROM " + PreviewContent.class.getSimpleName() + " pc " +
-                        "JOIN pc.bitstream b " +
-                        "WHERE b.id = :bitstream_id " +
-                        "AND pc.id NOT IN (SELECT child.id FROM " + PreviewContent.class.getSimpleName() + " parent " +
-                        "JOIN parent.sub child)"
+        Query query = getHibernateSession(context).createNativeQuery(
+                "SELECT pc.* FROM previewcontent pc " +
+                        "JOIN bitstream b ON pc.bitstream_id = b.uuid " +
+                        "WHERE b.uuid = :bitstream_id " +
+                        "AND NOT EXISTS (SELECT 1 FROM preview2preview p2p WHERE pc.previewcontent_id = p2p.child_id)",
+                PreviewContent.class
         );
         query.setParameter("bitstream_id", bitstream.getID());
         query.setHint("org.hibernate.cacheable", Boolean.TRUE);


### PR DESCRIPTION
Would be nicer if it was not a native query, but the goal here is to avoid any unnecessary joins.

dspace-dev has currently ~176k rows in previewcontent and ~175k rows in preview2preview. With this change the mean_exec_time as reported by pg_stat_statements drops from ~3000ms to ~39ms.

It's faster in the UI but not as much as I'd like.
![image](https://github.com/user-attachments/assets/041daf2a-0749-4b57-88ca-eeecc96899b7)
I'm guessing that's due to a lot of unnecessary data transfers. It downloads 2.7MB and I haven't yet decided I want to see a file preview. So the preview feature should probably be split into two parts - indicate a preview is available and only when user wants to see the preview fetch the additional data (and not all of it, just for the selected bitstream). But this will be a separate issue