### PR TITLE
issue 1233: requiredmetadata curation task - fix NPE + few other issues

### DIFF
--- a/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
@@ -92,8 +92,8 @@ public class RequiredMetadata extends AbstractCurationTask {
 
                 // when the owning collection is null it may be the case
                 // when the item is a workspace item or a workflow item
-                try {
-                    if (collection == null) {
+                if (collection == null) {
+                    try {
                         Context context = Curator.curationContext();
                         if (itemService.isInProgressSubmission(context, item)) {
                             WorkflowItem workflowItem = workflowItemService.findByItem(context, item);
@@ -106,9 +106,9 @@ public class RequiredMetadata extends AbstractCurationTask {
                                 }
                             }
                         }
+                    } catch (SQLException ex) {
+                        throw new IOException(ex.getMessage(), ex);
                     }
-                } catch (SQLException ex) {
-                    throw new IOException(ex.getMessage(), ex);
                 }
 
                 String resourceType = itemService.getMetadataFirstValue(

--- a/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
@@ -46,7 +46,7 @@ import org.dspace.workflow.factory.WorkflowServiceFactory;
  *
  * @author richardrodgers
  */
-@Suspendable(statusCodes = {-1})
+@Suspendable(statusCodes = {Curator.CURATE_ERROR})
 public class RequiredMetadata extends AbstractCurationTask {
     // map of DCInputSets
     protected DCInputsReader reader = null;

--- a/dspace-api/src/test/java/org/dspace/curate/RequiredMetadataIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/RequiredMetadataIT.java
@@ -11,15 +11,26 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.sql.SQLException;
 
 import org.dspace.AbstractIntegrationTestWithDatabase;
-import org.dspace.builder.CollectionBuilder;
-import org.dspace.builder.CommunityBuilder;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.content.Collection;
+import org.dspace.content.Community;
 import org.dspace.content.Item;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.identifier.factory.IdentifierServiceFactory;
+import org.dspace.identifier.service.IdentifierService;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -30,6 +41,45 @@ import org.junit.Test;
 public class RequiredMetadataIT extends AbstractIntegrationTestWithDatabase {
     private static final String TASK_NAME = "requiredmetadata";
 
+    protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+    protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+    protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    protected WorkspaceItemService workspaceItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
+    protected IdentifierService identifierService = IdentifierServiceFactory.getInstance().getIdentifierService();
+
+    Community parentCommunity;
+    Collection collection;
+    Item item1;
+    Item item2;
+    WorkspaceItem workspaceItem;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        try {
+            //we have to create a new community in the database
+            context.turnOffAuthorisationSystem();
+            this.parentCommunity = communityService.create(null, context);
+            this.collection = collectionService.create(context, parentCommunity, "123456789/113");
+            this.workspaceItem = workspaceItemService.create(context, collection, true);
+            identifierService.register(context, workspaceItem.getItem());
+            item1 = ItemBuilder.createItem(context, collection)
+                    .withHandle("123456789/113-1")
+                    .withMetadata("dc", "title", null, "Test item")
+                    .withMetadata("dc", "date", "issued", "2025-07-23")
+                    .build();
+            item2 = ItemBuilder.createItem(context, collection)
+                    .withHandle("123456789/113-2")
+                    .build();
+            context.restoreAuthSystemState();
+        } catch (AuthorizeException ex) {
+            fail("Authorization Error in init: " + ex.getMessage());
+        } catch (SQLException ex) {
+            fail("SQL Error in init: " + ex.getMessage());
+        }
+    }
+
     @Test
     public void testPerform() throws IOException {
         Curator curator = new Curator();
@@ -38,41 +88,40 @@ public class RequiredMetadataIT extends AbstractIntegrationTestWithDatabase {
         curator.setReporter(reporter);
 
         context.setCurrentUser(admin);
-        parentCommunity = CommunityBuilder.createCommunity(context).build();
 
-        Collection collection = CollectionBuilder.createCollection(context, parentCommunity, "123456789/113")
-                                                 .build();
-        Item item1 = ItemBuilder.createItem(context, collection)
-                .withHandle("123456789/113-1")
-                .build();
-
-        Item item2 = ItemBuilder.createItem(context, collection)
-                .withHandle("123456789/113-2")
-                .withMetadata("dc", "title", null, "Test item")
-                .withMetadata("dc", "date", "issued", "2025-07-23")
-                .build();
-
-        String failResult =
-                "Item: 123456789/113-1 missing required field: dc.title. missing required field: dc.date.issued";
-        String successResult = "Item: 123456789/113-2 has all required fields";
-
-        // run curateTask for item1 - should fail
-        curator.curate(context, item1);
+        // run curateTask for workspaceItem - should fail
+        curator.curate(context, workspaceItem.getItem().getHandle());
         assertEquals("Curation should fail", Curator.CURATE_FAIL, curator.getStatus(TASK_NAME));
-        assertEquals(failResult, curator.getResult(TASK_NAME));
-        assertThat(reporter.getReport(), contains(failResult));
+        assertEquals(failResultForItem(workspaceItem.getItem()), curator.getResult(TASK_NAME));
+        assertThat(reporter.getReport(), contains(failResultForItem(workspaceItem.getItem())));
         reporter.getReport().clear();
 
-        // run curateTask for item2 - should pass
+        // run curateTask for item1 - should pass
+        curator.curate(context, item1);
+        assertEquals("Curation should succeed", Curator.CURATE_SUCCESS, curator.getStatus(TASK_NAME));
+        assertEquals(successResultForItem(item1), curator.getResult(TASK_NAME));
+        assertThat(reporter.getReport(), contains(successResultForItem(item1)));
+        reporter.getReport().clear();
+
+        // run curateTask for item2 - should fail
         curator.curate(context, item2);
-        assertEquals("Curation should succed", Curator.CURATE_SUCCESS, curator.getStatus(TASK_NAME));
-        assertEquals(successResult, curator.getResult(TASK_NAME));
-        assertThat(reporter.getReport(), contains(successResult));
+        assertEquals("Curation should fail", Curator.CURATE_FAIL, curator.getStatus(TASK_NAME));
+        assertEquals(failResultForItem(item2), curator.getResult(TASK_NAME));
+        assertThat(reporter.getReport(), contains(failResultForItem(item2)));
         reporter.getReport().clear();
 
         // run curateTask for collection
         curator.curate(context, collection);
-        assertThat(reporter.getReport(), containsInAnyOrder(failResult, successResult));
+        assertThat(reporter.getReport(), containsInAnyOrder(successResultForItem(item1), failResultForItem(item2)));
+    }
+
+    private static String failResultForItem(Item item) {
+        return "Item: " + item.getHandle()
+                + " missing required field: dc.title. missing required field: dc.date.issued";
+    }
+
+    private static String successResultForItem(Item item) {
+        return "Item: " + item.getHandle() + " has all required fields";
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/curate/RequiredMetadataIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/RequiredMetadataIT.java
@@ -1,0 +1,78 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.curate;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.junit.Test;
+
+/**
+ * Test for requiredmetadata curation task.
+ *
+ * @author mkuchtiak
+ */
+public class RequiredMetadataIT extends AbstractIntegrationTestWithDatabase {
+    private static final String TASK_NAME = "requiredmetadata";
+
+    @Test
+    public void testPerform() throws IOException {
+        Curator curator = new Curator();
+        curator.addTask(TASK_NAME);
+        CuratorReportTest.ListReporter reporter = new CuratorReportTest.ListReporter();
+        curator.setReporter(reporter);
+
+        context.setCurrentUser(admin);
+        parentCommunity = CommunityBuilder.createCommunity(context).build();
+
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity, "123456789/2")
+                                                 .build();
+        Item item1 = ItemBuilder.createItem(context, collection)
+                .withHandle("123456789/2-1")
+                .build();
+
+        Item item2 = ItemBuilder.createItem(context, collection)
+                .withHandle("123456789/2-2")
+                .withMetadata("dc", "title", null, "Test item")
+                .withMetadata("dc", "date", "issued", "2025-07-23")
+                .build();
+
+        String failResult =
+                "Item: 123456789/2-1 missing required field: dc.title. missing required field: dc.date.issued";
+        String successResult = "Item: 123456789/2-2 has all required fields";
+
+        // run curateTask for item1 - should fail
+        curator.curate(context, item1);
+        assertEquals("Curation should fail", Curator.CURATE_FAIL, curator.getStatus(TASK_NAME));
+        assertEquals(failResult, curator.getResult(TASK_NAME));
+        assertThat(reporter.getReport(), contains(failResult));
+        reporter.getReport().clear();
+
+        // run curateTask for item2 - should pass
+        curator.curate(context, item2);
+        assertEquals("Curation should succed", Curator.CURATE_SUCCESS, curator.getStatus(TASK_NAME));
+        assertEquals(successResult, curator.getResult(TASK_NAME));
+        assertThat(reporter.getReport(), contains(successResult));
+        reporter.getReport().clear();
+
+        // run curateTask for collection
+        curator.curate(context, collection);
+        assertThat(reporter.getReport(), containsInAnyOrder(failResult, successResult));
+    }
+
+}

--- a/dspace-api/src/test/java/org/dspace/curate/RequiredMetadataIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/RequiredMetadataIT.java
@@ -40,21 +40,21 @@ public class RequiredMetadataIT extends AbstractIntegrationTestWithDatabase {
         context.setCurrentUser(admin);
         parentCommunity = CommunityBuilder.createCommunity(context).build();
 
-        Collection collection = CollectionBuilder.createCollection(context, parentCommunity, "123456789/2")
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity, "123456789/113")
                                                  .build();
         Item item1 = ItemBuilder.createItem(context, collection)
-                .withHandle("123456789/2-1")
+                .withHandle("123456789/113-1")
                 .build();
 
         Item item2 = ItemBuilder.createItem(context, collection)
-                .withHandle("123456789/2-2")
+                .withHandle("123456789/113-2")
                 .withMetadata("dc", "title", null, "Test item")
                 .withMetadata("dc", "date", "issued", "2025-07-23")
                 .build();
 
         String failResult =
-                "Item: 123456789/2-1 missing required field: dc.title. missing required field: dc.date.issued";
-        String successResult = "Item: 123456789/2-2 has all required fields";
+                "Item: 123456789/113-1 missing required field: dc.title. missing required field: dc.date.issued";
+        String successResult = "Item: 123456789/113-2 has all required fields";
 
         // run curateTask for item1 - should fail
         curator.curate(context, item1);


### PR DESCRIPTION
Issue #1233. Fixed following issues with **requiredmedatata curaton task** :

1. Fixed NPE, when requiredmedatata curaton task is started for workspace item or workflow item
2. Take into consideration the item's resource type when curation task is searched for required metadata
3. Do not show duplicate values for required metadata fields
4. Traverse through all items when requiredmedatata curation task is started for collection handle
     (formerly process was terminated when the first item was found with missing requiredmetadata)
