### PR TITLE
[Backport dtq-dev] Issue 1360: allow to change license in workflow item, in PATCH operation

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemRestRepository.java
@@ -7,11 +7,13 @@
  */
 package org.dspace.app.rest.repository;
 
+import static org.dspace.app.rest.repository.ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE;
 import static org.dspace.xmlworkflow.state.actions.processingaction.ProcessingAction.SUBMIT_EDIT_METADATA;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 
@@ -27,6 +29,7 @@ import org.dspace.app.rest.model.WorkflowItemRest;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.Patch;
 import org.dspace.app.rest.submit.SubmissionService;
+import org.dspace.app.rest.utils.ClarinLicenseUtils;
 import org.dspace.app.rest.utils.SolrOAIReindexer;
 import org.dspace.app.util.SubmissionConfigReaderException;
 import org.dspace.authorize.AuthorizeException;
@@ -35,6 +38,8 @@ import org.dspace.content.Item;
 import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
+import org.dspace.content.service.clarin.ClarinLicenseResourceMappingService;
+import org.dspace.content.service.clarin.ClarinLicenseService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
@@ -113,6 +118,12 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
 
     @Autowired
     private SolrOAIReindexer solrOAIReindexer;
+
+    @Autowired
+    ClarinLicenseService clarinLicenseService;
+
+    @Autowired
+    ClarinLicenseResourceMappingService clarinLicenseResourceMappingService;
 
     private SubmissionConfigService submissionConfigService;
 
@@ -196,7 +207,7 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
 
     @Override
     public WorkflowItemRest upload(HttpServletRequest request, String apiCategory, String model, Integer id,
-                                   MultipartFile file) throws SQLException {
+                                   MultipartFile file) throws SQLException, AuthorizeException {
 
         Context context = obtainContext();
         WorkflowItemRest wsi = findOne(context, id);
@@ -222,12 +233,19 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
         WorkflowItemRest wsi = findOne(context, id);
         XmlWorkflowItem source = wis.find(context, id);
 
+        if (source == null) {
+            throw new ResourceNotFoundException("WorkflowItem with id " + id + " not found");
+        }
+
         this.checkIfEditMetadataAllowedInCurrentStep(context, source);
 
         for (Operation op : operations) {
             //the value in the position 0 is a null value
             String[] path = op.getPath().substring(1).split("/", 3);
-            if (OPERATION_PATH_SECTIONS.equals(path[0])) {
+            if (OPERATION_PATH_LICENSE_RESOURCE.equals(path[0])) {
+                ClarinLicenseUtils.updateLicenseForItem(context,
+                        itemService, clarinLicenseService, clarinLicenseResourceMappingService, source, op);
+            } else if (OPERATION_PATH_SECTIONS.equals(path[0])) {
                 String section = path[1];
                 submissionService.evaluatePatchToInprogressSubmission(context, request, source, wsi, section, op);
             } else {
@@ -268,14 +286,24 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
      * @param context               Context
      * @param xmlWorkflowItem       WorkflowItem of the task
      */
-    private void checkIfEditMetadataAllowedInCurrentStep(Context context, XmlWorkflowItem xmlWorkflowItem) {
+    private void checkIfEditMetadataAllowedInCurrentStep(Context context, XmlWorkflowItem xmlWorkflowItem)
+            throws AuthorizeException {
         try {
-            ClaimedTask claimedTask = claimedTaskService.findByWorkflowIdAndEPerson(context, xmlWorkflowItem,
-                context.getCurrentUser());
-            if (claimedTask == null) {
+            List<ClaimedTask> claimTasks = claimedTaskService.findByWorkflowItem(context, xmlWorkflowItem);
+            if (claimTasks.isEmpty()) {
                 throw new UnprocessableEntityException("WorkflowItem with id " + xmlWorkflowItem.getID()
-                    + " has not been claimed yet.");
+                        + " has not been claimed yet.");
             }
+
+            ClaimedTask claimedTask = claimTasks.stream()
+                    .filter(ct -> Objects.equals(ct.getOwner(), context.getCurrentUser()))
+                    .findFirst()
+                    .orElse(null);
+            if (claimedTask == null) {
+                throw new AuthorizeException("The current user hasn't claimed the workflow item with id " +
+                        xmlWorkflowItem.getID() + ", so the user cannot patch this item");
+            }
+
             Workflow workflow = workflowFactory.getWorkflow(claimedTask.getWorkflowItem().getCollection());
             Step step = workflow.getStep(claimedTask.getStepID());
             WorkflowActionConfig currentActionConfig = step.getActionConfig(claimedTask.getActionID());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
@@ -19,11 +19,9 @@ import java.net.URLConnection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -31,13 +29,11 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.WorkspaceItemConverter;
-import org.dspace.app.rest.exception.ClarinLicenseNotFoundException;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.ErrorRest;
 import org.dspace.app.rest.model.WorkspaceItemRest;
-import org.dspace.app.rest.model.patch.JsonValueEvaluator;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.Patch;
 import org.dspace.app.rest.model.patch.ReplaceOperation;
@@ -45,20 +41,18 @@ import org.dspace.app.rest.repository.handler.service.UriListHandlerService;
 import org.dspace.app.rest.submit.SubmissionService;
 import org.dspace.app.rest.submit.UploadableStep;
 import org.dspace.app.rest.utils.BigMultipartFile;
+import org.dspace.app.rest.utils.ClarinLicenseUtils;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.app.util.SubmissionConfig;
 import org.dspace.app.util.SubmissionConfigReaderException;
 import org.dspace.app.util.SubmissionStepConfig;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
-import org.dspace.content.Bitstream;
-import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.LicenseUtils;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.WorkspaceItem;
-import org.dspace.content.clarin.ClarinLicense;
 import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.CollectionService;
@@ -84,7 +78,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
-import org.springframework.util.ObjectUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 
@@ -236,7 +229,8 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
             //the value in the position 0 is a null value
             String[] path = op.getPath().substring(1).split("/", 3);
             if (OPERATION_PATH_LICENSE_RESOURCE.equals(path[0])) {
-                this.maintainLicensesForItem(context, source, op);
+                ClarinLicenseUtils.updateLicenseForItem(context,
+                        itemService, clarinLicenseService, clarinLicenseResourceMappingService, source, op);
                 continue;
             }
             if (OPERATION_PATH_LICENSE_GRANTED.equals(path[0])) {
@@ -474,90 +468,6 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
         if (shouldDeleteFile) {
             FileUtils.forceDelete(file);
         }
-    }
-
-    /**
-     * Detach the clarin license from the bitstreams and if the clarin license is not null attach the
-     * new clarin license to the bitstream.
-     * @param context DSpace context object
-     * @param source WorkspaceItem object
-     * @param op should be ReplaceOperation, if it is not - do nothing
-     */
-    private void maintainLicensesForItem(Context context, WorkspaceItem source, Operation op)
-            throws SQLException, AuthorizeException {
-        // Get item
-        Item item = source.getItem();
-        if (Objects.isNull(item)) {
-            // add log
-            return;
-        }
-        // Get value from operation
-        if (!(op instanceof ReplaceOperation)) {
-            // add log
-            return;
-        }
-
-        String clarinLicenseName;
-        if (op.getValue() instanceof String) {
-            clarinLicenseName = (String) op.getValue();
-        } else {
-            JsonValueEvaluator jsonValEvaluator = (JsonValueEvaluator) op.getValue();
-            // replace operation has value wrapped in the ObjectNode
-            JsonNode jsonNodeValue = jsonValEvaluator.getValueNode().get("value");
-            if (ObjectUtils.isEmpty(jsonNodeValue)) {
-                log.info("Cannot get clarin license name value from the ReplaceOperation.");
-                return;
-            }
-            clarinLicenseName = jsonNodeValue.asText();
-        }
-
-        // Get clarin license by definition
-        ClarinLicense clarinLicense = clarinLicenseService.findByName(context, clarinLicenseName);
-        if (StringUtils.isNotBlank(clarinLicenseName) && Objects.isNull(clarinLicense)) {
-            throw new ClarinLicenseNotFoundException("Cannot patch workspace item with id: " + source.getID() + "," +
-                    " because the clarin license with name: " + clarinLicenseName + " isn't supported in" +
-                    " the CLARIN/DSpace");
-        }
-
-        // Clear the license metadata from the item
-        clarinLicenseService.clearLicenseMetadataFromItem(context, item);
-
-        // Detach the clarin licenses from the uploaded bitstreams
-        List<Bundle> bundles = item.getBundles(Constants.CONTENT_BUNDLE_NAME);
-        for (Bundle bundle : bundles) {
-            List<Bitstream> bitstreamList = bundle.getBitstreams();
-            for (Bitstream bitstream : bitstreamList) {
-                // in case bitstream ID exists in license table for some reason .. just remove it
-                this.clarinLicenseResourceMappingService.detachLicenses(context, bitstream);
-            }
-        }
-
-        // Save changes to database
-        itemService.update(context, item);
-
-        if (Objects.isNull(clarinLicense)) {
-            log.info("The clarin license is null so all item metadata for license was cleared and the" +
-                    "licenses was detached.");
-            return;
-        }
-
-        // If the clarin license is not null that means some clarin license was updated and accepted
-        // Attach the new clarin license to every bitstream and add clarin license values to the item metadata.
-
-        // update item metadata with license data
-        clarinLicenseService.addLicenseMetadataToItem(context, clarinLicense, item);
-
-        // Attach the clarin license to the bitstreams
-        for (Bundle bundle : bundles) {
-            List<Bitstream> bitstreamList = bundle.getBitstreams();
-            for (Bitstream bitstream : bitstreamList) {
-                // in case bitstream ID exists in license table for some reason .. just remove it
-                this.clarinLicenseResourceMappingService.attachLicense(context, clarinLicense, bitstream);
-            }
-        }
-
-        // Save changes to database
-        itemService.update(context, item);
     }
 
     private void grantDistributionLicense(Context context, WorkspaceItem source, Operation op)

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ClarinLicenseUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ClarinLicenseUtils.java
@@ -1,0 +1,147 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.utils;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.app.rest.exception.ClarinLicenseNotFoundException;
+import org.dspace.app.rest.exception.DSpaceBadRequestException;
+import org.dspace.app.rest.model.patch.JsonValueEvaluator;
+import org.dspace.app.rest.model.patch.Operation;
+import org.dspace.app.rest.model.patch.ReplaceOperation;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.InProgressSubmission;
+import org.dspace.content.Item;
+import org.dspace.content.clarin.ClarinLicense;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.clarin.ClarinLicenseResourceMappingService;
+import org.dspace.content.service.clarin.ClarinLicenseService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+
+/**
+ * Utility class to manage the CLARIN license in DSpace REST API.
+ *
+ * @author Milan Kuchtiak (Charles University, Prague, Czech Republic)
+ */
+public class ClarinLicenseUtils {
+
+    private static final Logger log = LogManager.getLogger(ClarinLicenseUtils.class);
+
+    private ClarinLicenseUtils() {}
+
+    /**
+     * Detach the clarin license from the bitstreams and if the clarin license is not null attach the
+     * new clarin license to the bitstream.
+     * @param context DSpace context object
+     * @param itemService the item service
+     * @param clarinLicenseService the clarin license service
+     * @param clarinLicenseResourceMappingService the clarin license resource mapping service
+     * @param source InProgressSubmission object which may contain the item with bitstreams
+     *               to which the clarin license is attached
+     * @param op should be ReplaceOperation, if it is not - do nothing
+     */
+    public static void updateLicenseForItem(Context context,
+                                            ItemService itemService,
+                                            ClarinLicenseService clarinLicenseService,
+                                            ClarinLicenseResourceMappingService clarinLicenseResourceMappingService,
+                                            InProgressSubmission source,
+                                            Operation op) throws SQLException, AuthorizeException {
+        // Get item
+        Item item = source.getItem();
+        if (Objects.isNull(item)) {
+            throw new IllegalStateException("The item is null for the submission with id: " + source.getID() +
+                    " so the clarin license cannot be updated.");
+        }
+        // Get value from operation
+        if (!(op instanceof ReplaceOperation)) {
+            throw new DSpaceBadRequestException("The operation to update the license must be the 'replace' operation");
+        }
+
+        String clarinLicenseName;
+        if (op.getValue() instanceof String) {
+            clarinLicenseName = (String) op.getValue();
+        } else {
+            if (!(op.getValue() instanceof JsonValueEvaluator)) {
+                throw wrongValueFormatException(op);
+            }
+            JsonValueEvaluator jsonValEvaluator = (JsonValueEvaluator) op.getValue();
+            if (!(jsonValEvaluator.getValueNode() instanceof ObjectNode)) {
+                throw wrongValueFormatException(op);
+            }
+            // replace operation has value wrapped in the ObjectNode
+            JsonNode jsonNodeValue = jsonValEvaluator.getValueNode().get("value");
+            if (jsonNodeValue != null && jsonNodeValue.isTextual()) {
+                clarinLicenseName = jsonNodeValue.asText();
+            } else {
+                throw wrongValueFormatException(op);
+            }
+        }
+
+        // Get clarin license by definition
+        ClarinLicense clarinLicense = clarinLicenseService.findByName(context, clarinLicenseName);
+        if (StringUtils.isNotBlank(clarinLicenseName) && Objects.isNull(clarinLicense)) {
+            throw new ClarinLicenseNotFoundException("Cannot patch submission item with id: " + source.getID() + "," +
+                    " because the clarin license with name: " + clarinLicenseName + " doesn't exist");
+        }
+
+        // Clear the license metadata from the item
+        clarinLicenseService.clearLicenseMetadataFromItem(context, item);
+
+        // Detach the clarin licenses from the uploaded bitstreams
+        List<Bundle> bundles = item.getBundles(Constants.CONTENT_BUNDLE_NAME);
+        for (Bundle bundle : bundles) {
+            List<Bitstream> bitstreamList = bundle.getBitstreams();
+            for (Bitstream bitstream : bitstreamList) {
+                // in case bitstream ID exists in license table for some reason .. just remove it
+                clarinLicenseResourceMappingService.detachLicenses(context, bitstream);
+            }
+        }
+
+        // Save changes to database
+        itemService.update(context, item);
+
+        if (Objects.isNull(clarinLicense)) {
+            log.info("The clarin license is null so all item metadata for license was cleared and the" +
+                    "licenses was detached.");
+            return;
+        }
+
+        // If the clarin license is not null that means some clarin license was updated and accepted
+        // Attach the new clarin license to every bitstream and add clarin license values to the item metadata.
+
+        // update item metadata with license data
+        clarinLicenseService.addLicenseMetadataToItem(context, clarinLicense, item);
+
+        // Attach the clarin license to the bitstreams
+        for (Bundle bundle : bundles) {
+            List<Bitstream> bitstreamList = bundle.getBitstreams();
+            for (Bitstream bitstream : bitstreamList) {
+                // in case bitstream ID exists in license table for some reason .. just remove it
+                clarinLicenseResourceMappingService.attachLicense(context, clarinLicense, bitstream);
+            }
+        }
+
+        // Save changes to database
+        itemService.update(context, item);
+    }
+
+    private static DSpaceBadRequestException wrongValueFormatException(Operation op) {
+        return new DSpaceBadRequestException("Unsupported value type for operation: " + op.getOp()
+                + ". Expected a string or an object with a textual 'value' field.");
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinWorkflowItemRestRepositoryIT.java
@@ -15,16 +15,29 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.rest.model.patch.AddOperation;
+import org.dspace.app.rest.model.patch.Operation;
+import org.dspace.app.rest.model.patch.ReplaceOperation;
+import org.dspace.app.rest.repository.ClarinLicenseRestRepository;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.ClaimedTaskBuilder;
+import org.dspace.builder.ClarinLicenseBuilder;
+import org.dspace.builder.ClarinLicenseLabelBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.EPersonBuilder;
@@ -35,12 +48,18 @@ import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.WorkspaceItem;
+import org.dspace.content.clarin.ClarinLicense;
+import org.dspace.content.clarin.ClarinLicenseLabel;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.content.service.clarin.ClarinLicenseLabelService;
+import org.dspace.content.service.clarin.ClarinLicenseService;
 import org.dspace.eperson.EPerson;
 import org.dspace.license.service.CreativeCommonsService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
+import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
+import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.dspace.xmlworkflow.storedcomponents.service.CollectionRoleService;
 import org.dspace.xmlworkflow.storedcomponents.service.XmlWorkflowItemService;
 import org.hamcrest.Matchers;
@@ -77,6 +96,11 @@ public class ClarinWorkflowItemRestRepositoryIT extends AbstractControllerIntegr
 
     @Autowired
     private ItemService itemService;
+
+    @Autowired
+    private ClarinLicenseService clarinLicenseService;
+    @Autowired
+    private ClarinLicenseLabelService clarinLicenseLabelService;
 
     Item item;
 
@@ -319,5 +343,175 @@ public class ClarinWorkflowItemRestRepositoryIT extends AbstractControllerIntegr
             }
         }
         assertThat(containsSubmitterProvenance, is(true));
+    }
+
+    // When some input field has <type-bind field="something">...</type-bind> in the submission-forms.xml
+    @Test
+    public void shouldCreateItemWithCustomTypeBindField() throws Exception {
+        context.turnOffAuthorisationSystem();
+        String CITATION_VALUE = "Some citation";
+
+        //** GIVEN **
+        //1. A community with one collection.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+
+        // Submitter group - allow deposit a new item without workflow
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                .withName("Collection")
+                .build();
+
+        //3. a workspace item
+        WorkspaceItem wsitem = WorkspaceItemBuilder.createWorkspaceItem(context, col1)
+                .withTitle("Type-bind test")
+                .withIssueDate("2017-10-17")
+                .grantLicense()
+                .withMetadata("dc", "identifier", "citation", CITATION_VALUE)
+                .build();
+
+        context.restoreAuthSystemState();
+
+        // get the submitter auth token
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        // submit the workspaceitem to start the workflow
+        getClient(authToken)
+                .perform(post(BASE_REST_SERVER_URL + "/api/workflow/workflowitems")
+                        .content("/api/submission/workspaceitems/" + wsitem.getID())
+                        .contentType(textUriContentType))
+                .andExpect(status().isCreated());
+
+        // Load deposited item and check the provenance metadata
+        Item depositedItem = itemService.find(context, wsitem.getItem().getID());
+        List<MetadataValue> mvList = itemService.getMetadata(depositedItem, "dc", "identifier",
+                "citation", Item.ANY);
+        assertFalse(mvList.isEmpty());
+        assertThat(mvList.get(0).getValue(), is(CITATION_VALUE));
+    }
+
+    @Test
+    public void patchUpdateClarinLicense() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        // create Clarin License Label
+        ClarinLicenseLabel clarinLicenseLabel = ClarinLicenseLabelBuilder.createClarinLicenseLabel(context).build();
+        clarinLicenseLabel.setLabel("CC");
+        clarinLicenseLabel.setExtended(false);
+        clarinLicenseLabel.setTitle("CLL Title1");
+        clarinLicenseLabelService.update(context, clarinLicenseLabel);
+
+        // create Clarin License
+        ClarinLicense clarinLicense = ClarinLicenseBuilder.createClarinLicense(context).build();
+        clarinLicense.setName("CL Name");
+        clarinLicense.setConfirmation(ClarinLicense.Confirmation.NOT_REQUIRED);
+        clarinLicense.setDefinition("CL Definition");
+        clarinLicense.setRequiredInfo("CL Req");
+        // add clarinLicenseLabel to  clarinLicense
+        Set<ClarinLicenseLabel> clarinLicenseLabels = new HashSet<>();
+        clarinLicenseLabels.add(clarinLicenseLabel);
+        clarinLicense.setLicenseLabels(clarinLicenseLabels);
+        clarinLicenseService.update(context, clarinLicense);
+
+        // community with one collection.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1")
+                .withWorkflowGroup("editor", eperson).build();
+
+        // create a normal user to use as submitter
+        EPerson submitter = EPersonBuilder.createEPerson(context)
+                .withEmail("submitter@example.com")
+                .withPassword("dspace")
+                .build();
+
+        // claimed task with workflow item in edit step
+        ClaimedTask claimedTask = ClaimedTaskBuilder.createClaimedTask(context, col, eperson)
+                .withTitle("Workflow Item")
+                .withIssueDate("2026-05-18")
+                .withSubject("Extra Entry")
+                .grantLicense()
+                .build();
+        claimedTask.setStepID("editstep");
+        claimedTask.setActionID("editaction");
+        XmlWorkflowItem wfItem = claimedTask.getWorkflowItem();
+
+        context.restoreAuthSystemState();
+
+        // prepare a patch targeting the clarin license resource path
+        List<Operation> ops = new ArrayList<>();
+        ops.add(new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE, "CL Name"));
+
+        String submitterToken = getAuthToken(submitter.getEmail(), "dspace");
+
+        // The submitter shouldn't be allowed to patch clarin license
+        // because the workflow item was claimed by the other user (eperson),
+        // and the submitter doesn't have permissions to edit it,
+        // so the patch request should be rejected with error 403(Forbidden)
+        getClient(submitterToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isForbidden());
+
+        String editorToken = getAuthToken(eperson.getEmail(), password);
+
+        ops.set(0, new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE, "Wrong CL"));
+
+        // The wrong clarin license name value should be rejected with 404 Not Found
+        getClient(editorToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isNotFound());
+
+        // The valid clarin license name can be in the form of a simple string or
+        // in the form of a map with "value" key, but it should be accepted in both cases
+        ops.set(0, new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE, "CL Name"));
+
+        getClient(editorToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+        Map<String, String> wrappedValue = new HashMap<String, String>();
+        wrappedValue.put("value", "CL Name");
+        ops.set(0, new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE,
+                wrappedValue));
+
+        getClient(editorToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+        // The wrapped value should contain the "value" key, otherwise it is invalid
+        Map<String, String> invalidWrappedValue1 = new HashMap<String, String>();
+        ops.set(0, new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE,
+                invalidWrappedValue1));
+
+        getClient(editorToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isBadRequest());
+
+        // The wrapped value should be in a map, not in a list
+        List<String> invalidWrappedValue2 = new ArrayList<>();
+        invalidWrappedValue2.add("CL Name");
+        ops.set(0, new ReplaceOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE,
+                invalidWrappedValue2));
+
+        getClient(editorToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isBadRequest());
+
+        // The only accepted operation for clarin license resource is "replace",
+        // "add" operation should be rejected with 400 Bad Request even with the valid value
+        ops.set(0, new AddOperation("/" + ClarinLicenseRestRepository.OPERATION_PATH_LICENSE_RESOURCE,
+                "CL Name"));
+
+        getClient(editorToken).perform(patch("/api/workflow/workflowitems/" + wfItem.getID())
+                        .content(getPatchContent(ops))
+                        .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/TaskRestRepositoriesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/TaskRestRepositoriesIT.java
@@ -2893,7 +2893,7 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
         getClient(authToken).perform(patch("/api/workflow/workflowitems/" + witem.getID())
             .content(patchBody)
             .contentType(javax.ws.rs.core.MediaType.APPLICATION_JSON_PATCH_JSON))
-            .andExpect(status().isUnprocessableEntity());
+            .andExpect(status().isForbidden());
     }
 
     @Test


### PR DESCRIPTION
Backport of #1365 to `dtq-dev`.

The automated backport (port-pr) failed because the cherry-pick of `40672c3241` conflicted with `dtq-dev`. Resolved manually:

- **`WorkspaceItemRestRepository.java`** — #1365 removes the local `maintainLicensesForItem` method (its logic moved to the shared `ClarinLicenseUtils.updateLicenseForItem`) and switches the call site accordingly. The conflict region collided that deleted method against an unrelated `findByShareToken` method that exists in `clarin-v7` but **not** in `dtq-dev` (share-a-submission is not present here), so `findByShareToken` was intentionally not introduced. Removed the now-unused `ObjectUtils` (per #1365) and `CollectionUtils` (its only user was the absent `findByShareToken`) imports.
- **`ClarinWorkflowItemRestRepositoryIT.java`** — purely additive; kept the new #1365 test methods.
- `WorkflowItemRestRepository.java`, `TaskRestRepositoriesIT.java`, and the new `ClarinLicenseUtils.java` applied cleanly.

Maven is not available locally in this environment, so the resolution was verified by manual audit (import/usage consistency, brace balance, dependency presence on `dtq-dev`) rather than a local build — CI compiles/tests this branch.