### PR TITLE
Issue 1228: return error 400 rather than error 500 on anonymous user file download

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -28,6 +28,7 @@ import javax.mail.MessagingException;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.NotFoundException;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -93,6 +94,9 @@ public class ClarinUserMetadataRestController {
     @Autowired
     ConfigurationService configurationService;
 
+    @Autowired
+    ObjectMapper objectMapper;
+
     // Enum to distinguish between the two types of the email
     enum MailType { ALLZIP, BITSTREAM }
 
@@ -129,7 +133,7 @@ public class ClarinUserMetadataRestController {
         ClarinLicense clarinLicense = null;
         // Get ClarinUserMetadataRest Array from the request body
         ClarinUserMetadataRest[] clarinUserMetadataRestArray =
-                new ObjectMapper().readValue(request.getInputStream(), ClarinUserMetadataRest[].class);
+                objectMapper.readValue(request.getInputStream(), ClarinUserMetadataRest[].class);
         if (Objects.isNull(clarinUserMetadataRestArray)) {
             throw new RuntimeException("The clarinUserMetadataRestArray cannot be null. It could be empty, but" +
                     " not null");
@@ -228,12 +232,16 @@ public class ClarinUserMetadataRestController {
             throw new AuthorizeException("Anonymous user is not allowed to get access token");
         }
 
-        // Get ClarinUserMetadataRest Array from the request body
-        ClarinUserMetadataRest[] clarinUserMetadataRestArray =
-                new ObjectMapper().readValue(request.getInputStream(), ClarinUserMetadataRest[].class);
-        if (Objects.isNull(clarinUserMetadataRestArray)) {
-            throw new RuntimeException("The clarinUserMetadataRestArray cannot be null. It could be empty, but" +
-                    " not null");
+        ClarinUserMetadataRest[]  clarinUserMetadataRestArray;
+        try {
+            clarinUserMetadataRestArray =
+                    objectMapper.readValue(request.getInputStream(), ClarinUserMetadataRest[].class);
+            if (Objects.isNull(clarinUserMetadataRestArray)) {
+                throw new RuntimeException("The clarinUserMetadataRestArray cannot be null. It could be empty, but" +
+                        " not null");
+            }
+        } catch (JsonMappingException ex) {
+            throw new DSpaceBadRequestException("Missing or Invalid User Data", ex);
         }
 
         // Convert Array to the List

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -28,8 +28,9 @@ import javax.mail.MessagingException;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.NotFoundException;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.JsonParseException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
@@ -58,7 +59,6 @@ import org.dspace.core.Email;
 import org.dspace.core.I18nUtil;
 import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
-import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -103,8 +103,8 @@ public class ClarinUserMetadataRestController {
     @RequestMapping(value = "/zip", method = POST, consumes = APPLICATION_JSON)
     @PreAuthorize("permitAll()")
     public ResponseEntity manageUserMetadataForZIP(@RequestParam("itemUUID") UUID itemUUID,
-                                             HttpServletRequest request)
-            throws SQLException, ParseException, IOException, AuthorizeException, MessagingException {
+                                                   HttpServletRequest request)
+            throws SQLException, IOException, AuthorizeException {
 
         // Get context from the request
         Context context = obtainContext(request);
@@ -131,13 +131,8 @@ public class ClarinUserMetadataRestController {
 
         boolean shouldEmailToken = false;
         ClarinLicense clarinLicense = null;
-        // Get ClarinUserMetadataRest Array from the request body
-        ClarinUserMetadataRest[] clarinUserMetadataRestArray =
-                objectMapper.readValue(request.getInputStream(), ClarinUserMetadataRest[].class);
-        if (Objects.isNull(clarinUserMetadataRestArray)) {
-            throw new RuntimeException("The clarinUserMetadataRestArray cannot be null. It could be empty, but" +
-                    " not null");
-        }
+
+        ClarinUserMetadataRest[] clarinUserMetadataRestArray = getClarinUserMetadata(request);
 
         // Convert Array to the List
         List<ClarinUserMetadataRest> clarinUserMetadataRestList = Arrays.asList(clarinUserMetadataRestArray);
@@ -195,8 +190,8 @@ public class ClarinUserMetadataRestController {
     @RequestMapping(method = POST, consumes = APPLICATION_JSON)
     @PreAuthorize("permitAll()")
     public ResponseEntity manageUserMetadata(@RequestParam("bitstreamUUID") UUID bitstreamUUID,
-                                                     HttpServletRequest request)
-            throws SQLException, ParseException, IOException, AuthorizeException, MessagingException {
+                                             HttpServletRequest request)
+            throws SQLException, IOException, AuthorizeException {
 
         // Get context from the request
         Context context = obtainContext(request);
@@ -232,17 +227,7 @@ public class ClarinUserMetadataRestController {
             throw new AuthorizeException("Anonymous user is not allowed to get access token");
         }
 
-        ClarinUserMetadataRest[]  clarinUserMetadataRestArray;
-        try {
-            clarinUserMetadataRestArray =
-                    objectMapper.readValue(request.getInputStream(), ClarinUserMetadataRest[].class);
-            if (Objects.isNull(clarinUserMetadataRestArray)) {
-                throw new RuntimeException("The clarinUserMetadataRestArray cannot be null. It could be empty, but" +
-                        " not null");
-            }
-        } catch (JsonMappingException ex) {
-            throw new DSpaceBadRequestException("Missing or Invalid User Data", ex);
-        }
+        ClarinUserMetadataRest[] clarinUserMetadataRestArray = getClarinUserMetadata(request);
 
         // Convert Array to the List
         List<ClarinUserMetadataRest> clarinUserMetadataRestList = Arrays.asList(clarinUserMetadataRestArray);
@@ -292,7 +277,7 @@ public class ClarinUserMetadataRestController {
                                            MailType mailType,
                                            List<ClarinUserMetadataRest> clarinUserMetadataRestList,
                                            String itemHandle)
-            throws IOException, SQLException, MessagingException {
+            throws IOException, MessagingException {
         if (StringUtils.isBlank(email)) {
             log.error("Cannot send email with download link because the email is empty.");
             throw new DSpaceBadRequestException("Cannot send email with download link because the email is empty.");
@@ -618,5 +603,26 @@ public class ClarinUserMetadataRestController {
             clarinUserMetadataList.add(clarinUserMetadata);
         }
         return clarinUserMetadataList;
+    }
+
+    /**
+     * Get ClarinUserMetadataRest array from the request body. Throws exception if the request body is empty or invalid.
+     *
+     * @param request request
+     * @return ClarinUserMetadataRest array
+     */
+    private ClarinUserMetadataRest[] getClarinUserMetadata(HttpServletRequest request) throws IOException {
+        ClarinUserMetadataRest[] clarinUserMetadataRestArray;
+        try {
+            clarinUserMetadataRestArray = objectMapper.readValue(
+                    request.getInputStream(), ClarinUserMetadataRest[].class);
+        } catch (JsonProcessingException | JsonParseException ex) {
+            throw new DSpaceBadRequestException("Missing or Invalid User Data", ex);
+        }
+        if (Objects.isNull(clarinUserMetadataRestArray)) {
+            throw new RuntimeException("The clarinUserMetadataRestArray cannot be null. It could be empty, but" +
+                    " not null");
+        }
+        return clarinUserMetadataRestArray;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -134,6 +134,7 @@ public class ClarinUserMetadataRestController {
 
         boolean shouldEmailToken = false;
         ClarinLicense clarinLicense = null;
+        Set<String> requiredInfoKeys = new HashSet<>();
 
         List<Bundle> bundles = item.getBundles("ORIGINAL");
         if (!bundles.isEmpty()) {
@@ -143,13 +144,15 @@ public class ClarinUserMetadataRestController {
                         this.getLicenseResourceMapping(context, bitstreams.get(0).getID());
                 clarinLicense = getClarinLicense(clarinLicenseResourceMapping);
                 shouldEmailToken = this.shouldEmailToken(clarinLicenseResourceMapping);
+                requiredInfoKeys.addAll(getRequiredInfoKeys(clarinLicense));
             }
         }
 
         ClarinUserMetadataRest[] clarinUserMetadataRestArray = getClarinUserMetadata(request);
+        checkForRequiredInfoKeys(clarinUserMetadataRestArray, requiredInfoKeys);
         List<ClarinUserMetadataRest> clarinUserMetadataRestList = (clarinLicense == null)
                 ? Arrays.asList(clarinUserMetadataRestArray)
-                : getFilteredUserMetadataForClarinLicense(clarinUserMetadataRestArray, clarinLicense);
+                : getFilteredUserMetadataForClarinLicense(clarinUserMetadataRestArray, requiredInfoKeys);
 
         for (Bundle original : bundles) {
             List<Bitstream> bss = original.getBitstreams();
@@ -234,8 +237,11 @@ public class ClarinUserMetadataRestController {
         }
 
         ClarinUserMetadataRest[] clarinUserMetadataRestArray = getClarinUserMetadata(request);
+
+        Set<String> requiredInfoKeys = getRequiredInfoKeys(clarinLicense);
+        checkForRequiredInfoKeys(clarinUserMetadataRestArray, requiredInfoKeys);
         List<ClarinUserMetadataRest> clarinUserMetadataRestList = getFilteredUserMetadataForClarinLicense(
-                clarinUserMetadataRestArray, clarinLicense);
+                clarinUserMetadataRestArray, requiredInfoKeys);
 
         if (Objects.isNull(currentUser)) {
             // The user is not signed in
@@ -632,25 +638,50 @@ public class ClarinUserMetadataRestController {
     }
 
     /**
-     * Filters the given array of ClarinUserMetadataRest objects to include only those with the key "IP" or those
-     * required by the given ClarinLicense.
+     * Gets the required info keys for the given ClarinLicense.
      *
-     * @param clarinUserMetadataRestArray the array of ClarinUserMetadataRest objects to filter
-     * @param clarinLicense the ClarinLicense object containing the required info keys
-     * @return a list of filtered ClarinUserMetadataRest objects
+     * @param clarinLicense the ClarinLicense object to get required info keys from
+     * @return Set of required info keys for the given ClarinLicense
      */
-    private static List<ClarinUserMetadataRest> getFilteredUserMetadataForClarinLicense(
-            ClarinUserMetadataRest[] clarinUserMetadataRestArray, ClarinLicense clarinLicense) {
-        Set<String> requiredInfoKeys = Optional.ofNullable(clarinLicense.getRequiredInfo())
+    private static Set<String> getRequiredInfoKeys(ClarinLicense clarinLicense) {
+        return Optional.ofNullable(clarinLicense.getRequiredInfo())
                 .map(requiredInfo -> Arrays.stream(requiredInfo.split(","))
                         .filter(StringUtils::isNotBlank)
                         .map(String::trim)
                         .collect(Collectors.toSet()))
-                .orElse(new HashSet<>());
-        requiredInfoKeys.add("IP");
+                .orElse(Set.of());
+    }
 
+    /**
+     * Checks if the given array of ClarinUserMetadataRest objects contains all required info keys.
+     *
+     * @param clarinUserMetadataRestArray the array of ClarinUserMetadataRest objects to check
+     * @param requiredInfoKeys the set of required info keys to check against
+     */
+    private static void checkForRequiredInfoKeys(ClarinUserMetadataRest[] clarinUserMetadataRestArray,
+                                                 Set<String> requiredInfoKeys) {
+        if (!requiredInfoKeys.stream().allMatch(requiredInfoKey ->
+                Arrays.stream(clarinUserMetadataRestArray)
+                        .anyMatch(clarinUserMetadataRest ->
+                                requiredInfoKey.equals(clarinUserMetadataRest.getMetadataKey())))) {
+            throw new DSpaceBadRequestException("Missing required user metadata keys for the license.");
+        }
+    }
+
+    /**
+     * Filters the given array of ClarinUserMetadataRest objects to include only those with the key "IP" or those
+     * required by the given ClarinLicense.
+     *
+     * @param clarinUserMetadataRestArray the array of ClarinUserMetadataRest objects to filter
+     * @param requiredInfoKeys the set of required keys for the given ClarinLicense
+     * @return a list of filtered ClarinUserMetadataRest objects
+     */
+    private static List<ClarinUserMetadataRest> getFilteredUserMetadataForClarinLicense(
+            ClarinUserMetadataRest[] clarinUserMetadataRestArray,
+            Set<String> requiredInfoKeys) {
         return Arrays.stream(clarinUserMetadataRestArray)
                 .filter(clarinUserMetadataRest ->
+                        "IP".equals(clarinUserMetadataRest.getMetadataKey()) ||
                         requiredInfoKeys.contains(clarinUserMetadataRest.getMetadataKey()))
                 .collect(Collectors.toList());
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -30,7 +30,6 @@ import javax.ws.rs.NotFoundException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.JsonParseException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
@@ -616,12 +615,11 @@ public class ClarinUserMetadataRestController {
         try {
             clarinUserMetadataRestArray = objectMapper.readValue(
                     request.getInputStream(), ClarinUserMetadataRest[].class);
-        } catch (JsonProcessingException | JsonParseException ex) {
+        } catch (JsonProcessingException ex) {
             throw new DSpaceBadRequestException("Missing or Invalid User Data", ex);
         }
         if (Objects.isNull(clarinUserMetadataRestArray)) {
-            throw new RuntimeException("The clarinUserMetadataRestArray cannot be null. It could be empty, but" +
-                    " not null");
+            throw new DSpaceBadRequestException("Missing or Invalid User Data");
         }
         return clarinUserMetadataRestArray;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -669,7 +669,8 @@ public class ClarinUserMetadataRestController {
                 OPTIONAL_METADATA_KEYS.contains(requiredInfoKey) ||
                 Arrays.stream(clarinUserMetadataRestArray)
                         .anyMatch(clarinUserMetadataRest ->
-                                requiredInfoKey.equals(clarinUserMetadataRest.getMetadataKey())))) {
+                                requiredInfoKey.equals(clarinUserMetadataRest.getMetadataKey())
+                                        && StringUtils.isNotBlank(clarinUserMetadataRest.getMetadataValue())))) {
             throw new DSpaceBadRequestException("Missing required user metadata keys for the license.");
         }
     }
@@ -688,8 +689,9 @@ public class ClarinUserMetadataRestController {
             Set<String> requiredInfoKeys) {
         return Arrays.stream(clarinUserMetadataRestArray)
                 .filter(clarinUserMetadataRest ->
-                        "IP".equals(clarinUserMetadataRest.getMetadataKey())
-                                || requiredInfoKeys.contains(clarinUserMetadataRest.getMetadataKey()))
+                        StringUtils.isNotBlank(clarinUserMetadataRest.getMetadataValue())
+                                && ("IP".equals(clarinUserMetadataRest.getMetadataKey())
+                                    || requiredInfoKeys.contains(clarinUserMetadataRest.getMetadataKey())))
                 .collect(Collectors.toList());
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -78,6 +78,8 @@ public class ClarinUserMetadataRestController {
 
     public static final String CHECK_EMAIL_RESPONSE_CONTENT = "checkEmail";
 
+    private static final List<String> OPTIONAL_METADATA_KEYS = List.of("ORGANIZATION");
+
     @Autowired
     ClarinUserMetadataService clarinUserMetadataService;
     @Autowired
@@ -639,6 +641,7 @@ public class ClarinUserMetadataRestController {
 
     /**
      * Gets the required info keys for the given ClarinLicense.
+     * Note that "SEND_TOKEN" is not considered required.
      *
      * @param clarinLicense the ClarinLicense object to get required info keys from
      * @return Set of required info keys for the given ClarinLicense
@@ -646,7 +649,8 @@ public class ClarinUserMetadataRestController {
     private static Set<String> getRequiredInfoKeys(ClarinLicense clarinLicense) {
         return Optional.ofNullable(clarinLicense.getRequiredInfo())
                 .map(requiredInfo -> Arrays.stream(requiredInfo.split(","))
-                        .filter(StringUtils::isNotBlank)
+                        .filter(s -> StringUtils.isNotBlank(s)
+                                && !"SEND_TOKEN".equals(s))
                         .map(String::trim)
                         .collect(Collectors.toSet()))
                 .orElse(Set.of());
@@ -654,6 +658,7 @@ public class ClarinUserMetadataRestController {
 
     /**
      * Checks if the given array of ClarinUserMetadataRest objects contains all required info keys.
+     * Note that the OPTIONAL_METADATA_KEYS are not required.
      *
      * @param clarinUserMetadataRestArray the array of ClarinUserMetadataRest objects to check
      * @param requiredInfoKeys the set of required info keys to check against
@@ -661,6 +666,7 @@ public class ClarinUserMetadataRestController {
     private static void checkForRequiredInfoKeys(ClarinUserMetadataRest[] clarinUserMetadataRestArray,
                                                  Set<String> requiredInfoKeys) {
         if (!requiredInfoKeys.stream().allMatch(requiredInfoKey ->
+                OPTIONAL_METADATA_KEYS.contains(requiredInfoKey) ||
                 Arrays.stream(clarinUserMetadataRestArray)
                         .anyMatch(clarinUserMetadataRest ->
                                 requiredInfoKey.equals(clarinUserMetadataRest.getMetadataKey())))) {
@@ -669,8 +675,9 @@ public class ClarinUserMetadataRestController {
     }
 
     /**
-     * Filters the given array of ClarinUserMetadataRest objects to include only those with the key "IP" or those
+     * Filters the given array of ClarinUserMetadataRest objects to include only those
      * required by the given ClarinLicense.
+     * Note that the "IP" should be included if present.
      *
      * @param clarinUserMetadataRestArray the array of ClarinUserMetadataRest objects to filter
      * @param requiredInfoKeys the set of required keys for the given ClarinLicense
@@ -681,8 +688,8 @@ public class ClarinUserMetadataRestController {
             Set<String> requiredInfoKeys) {
         return Arrays.stream(clarinUserMetadataRestArray)
                 .filter(clarinUserMetadataRest ->
-                        "IP".equals(clarinUserMetadataRest.getMetadataKey()) ||
-                        requiredInfoKeys.contains(clarinUserMetadataRest.getMetadataKey()))
+                        "IP".equals(clarinUserMetadataRest.getMetadataKey())
+                                || requiredInfoKeys.contains(clarinUserMetadataRest.getMetadataKey()))
                 .collect(Collectors.toList());
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -20,10 +20,14 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.mail.MessagingException;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.NotFoundException;
@@ -131,11 +135,22 @@ public class ClarinUserMetadataRestController {
         boolean shouldEmailToken = false;
         ClarinLicense clarinLicense = null;
 
-        ClarinUserMetadataRest[] clarinUserMetadataRestArray = getClarinUserMetadata(request);
-
-        // Convert Array to the List
-        List<ClarinUserMetadataRest> clarinUserMetadataRestList = Arrays.asList(clarinUserMetadataRestArray);
         List<Bundle> bundles = item.getBundles("ORIGINAL");
+        if (!bundles.isEmpty()) {
+            List<Bitstream> bitstreams = bundles.get(0).getBitstreams();
+            if (!bitstreams.isEmpty()) {
+                ClarinLicenseResourceMapping clarinLicenseResourceMapping =
+                        this.getLicenseResourceMapping(context, bitstreams.get(0).getID());
+                clarinLicense = getClarinLicense(clarinLicenseResourceMapping);
+                shouldEmailToken = this.shouldEmailToken(clarinLicenseResourceMapping);
+            }
+        }
+
+        ClarinUserMetadataRest[] clarinUserMetadataRestArray = getClarinUserMetadata(request);
+        List<ClarinUserMetadataRest> clarinUserMetadataRestList = (clarinLicense == null)
+                ? Arrays.asList(clarinUserMetadataRestArray)
+                : getFilteredUserMetadataForClarinLicense(clarinUserMetadataRestArray, clarinLicense);
+
         for (Bundle original : bundles) {
             List<Bitstream> bss = original.getBitstreams();
             for (Bitstream bitstream : bss) {
@@ -157,18 +172,11 @@ public class ClarinUserMetadataRestController {
                     this.processSignedInUser(context, currentUser, clarinUserMetadataRestList,
                             clarinLicenseResourceMapping, downloadToken);
                 }
-
-                // Check (only once) if the Clarin License contains the required information to SEND_TOKEN, which means
-                // the item must be downloaded after the user confirms the download with the token sent by email.
-                if (Objects.isNull(clarinLicense)) {
-                    clarinLicense = this.getClarinLicense(clarinLicenseResourceMapping);
-                    shouldEmailToken = this.shouldEmailToken(clarinLicenseResourceMapping);
-                }
             }
         }
 
         context.commit();
-        if (shouldEmailToken) {
+        if (clarinLicense != null && shouldEmailToken) {
             // If yes - send token to e-mail
             try {
                 String email = getEmailFromUserMetadata(clarinUserMetadataRestList);
@@ -199,7 +207,6 @@ public class ClarinUserMetadataRestController {
             return null;
         }
 
-
         Bitstream bitstream = bitstreamService.find(context, bitstreamUUID);
         if (Objects.isNull(bitstream)) {
             log.error("Cannot find the bitstream with ID: " + bitstreamUUID);
@@ -227,9 +234,9 @@ public class ClarinUserMetadataRestController {
         }
 
         ClarinUserMetadataRest[] clarinUserMetadataRestArray = getClarinUserMetadata(request);
+        List<ClarinUserMetadataRest> clarinUserMetadataRestList = getFilteredUserMetadataForClarinLicense(
+                clarinUserMetadataRestArray, clarinLicense);
 
-        // Convert Array to the List
-        List<ClarinUserMetadataRest> clarinUserMetadataRestList = Arrays.asList(clarinUserMetadataRestArray);
         if (Objects.isNull(currentUser)) {
             // The user is not signed in
             this.processNonSignedInUser(context, clarinUserMetadataRestList, clarinLicenseResourceMapping,
@@ -622,5 +629,29 @@ public class ClarinUserMetadataRestController {
             throw new DSpaceBadRequestException("Missing or Invalid User Data");
         }
         return clarinUserMetadataRestArray;
+    }
+
+    /**
+     * Filters the given array of ClarinUserMetadataRest objects to include only those with the key "IP" or those
+     * required by the given ClarinLicense.
+     *
+     * @param clarinUserMetadataRestArray the array of ClarinUserMetadataRest objects to filter
+     * @param clarinLicense the ClarinLicense object containing the required info keys
+     * @return a list of filtered ClarinUserMetadataRest objects
+     */
+    private static List<ClarinUserMetadataRest> getFilteredUserMetadataForClarinLicense(
+            ClarinUserMetadataRest[] clarinUserMetadataRestArray, ClarinLicense clarinLicense) {
+        Set<String> requiredInfoKeys = Optional.ofNullable(clarinLicense.getRequiredInfo())
+                .map(requiredInfo -> Arrays.stream(requiredInfo.split(","))
+                        .filter(StringUtils::isNotBlank)
+                        .map(String::trim)
+                        .collect(Collectors.toSet()))
+                .orElse(new HashSet<>());
+        requiredInfoKeys.add("IP");
+
+        return Arrays.stream(clarinUserMetadataRestArray)
+                .filter(clarinUserMetadataRest ->
+                        requiredInfoKeys.contains(clarinUserMetadataRest.getMetadataKey()))
+                .collect(Collectors.toList());
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClarinUserMetadataRestController.java
@@ -649,9 +649,8 @@ public class ClarinUserMetadataRestController {
     private static Set<String> getRequiredInfoKeys(ClarinLicense clarinLicense) {
         return Optional.ofNullable(clarinLicense.getRequiredInfo())
                 .map(requiredInfo -> Arrays.stream(requiredInfo.split(","))
-                        .filter(s -> StringUtils.isNotBlank(s)
-                                && !"SEND_TOKEN".equals(s))
                         .map(String::trim)
+                        .filter(s -> StringUtils.isNotBlank(s) && !"SEND_TOKEN".equals(s))
                         .collect(Collectors.toSet()))
                 .orElse(Set.of());
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
@@ -280,7 +280,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
                 .andExpect(jsonPath("$.page.totalElements", is(1)));
 
         // Get created User Metadata - there should be 2 records,
-        // because only 2 metadata fields are required by the license (EXTRA_EMAIL and ADDRESS)
+        // because only 2 metadata fields are required by the license (EXTRA_EMAIL and NAME)
         getClient(adminToken).perform(get("/api/core/clarinusermetadata")
                         .contentType(contentType))
                 .andExpect(status().isOk())
@@ -355,8 +355,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.page.totalElements", is(1)));
 
-        // Get created User Metadata - only NAME metadata is stored,
-        // because ORGANIZATION metadata is empty and should not be stored
+        // Get created User Metadata - there should be 2 records (ORGANIZATION and IP)
         getClient(adminToken).perform(get("/api/core/clarinusermetadata")
                         .contentType(contentType))
                 .andExpect(status().isOk())
@@ -368,15 +367,15 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
         this.prepareEnvironment("SEND_TOKEN,EXTRA_EMAIL,REQUIRED_ORGANIZATION", Confirmation.ALLOW_ANONYMOUS);
         ObjectMapper mapper = new ObjectMapper();
 
-        ClarinUserMetadataRest carinUserMetadata1 = new ClarinUserMetadataRest();
-        carinUserMetadata1.setMetadataKey("SEND_TOKEN");
+        ClarinUserMetadataRest clarinUserMetadata1 = new ClarinUserMetadataRest();
+        clarinUserMetadata1.setMetadataKey("SEND_TOKEN");
 
         ClarinUserMetadataRest clarinUserMetadata2 = new ClarinUserMetadataRest();
         clarinUserMetadata2.setMetadataKey("EXTRA_EMAIL");
         clarinUserMetadata2.setMetadataValue("test@test.edu");
 
         List<ClarinUserMetadataRest> clarinUserMetadataRestList = new ArrayList<>();
-        clarinUserMetadataRestList.add(carinUserMetadata1);
+        clarinUserMetadataRestList.add(clarinUserMetadata1);
         clarinUserMetadataRestList.add(clarinUserMetadata2);
 
         getClient().perform(post("/api/core/clarinusermetadata/manage?bitstreamUUID=" + bitstream.getID())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
@@ -226,6 +226,15 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
     }
 
     @Test
+    public void notAuthorizedUser_manageUserMetadata_withEmptyMetadata_shouldReturn_400() throws Exception {
+        this.prepareEnvironment(null, Confirmation.ALLOW_ANONYMOUS);
+        getClient().perform(post("/api/core/clarinusermetadata/manage?bitstreamUUID=" + bitstream.getID())
+                        .content(new byte[0])
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     public void authorizedUserWithoutMetadata_shouldReturnToken() throws Exception {
         this.prepareEnvironment("NAME", Confirmation.NOT_REQUIRED);
         context.turnOffAuthorisationSystem();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
@@ -235,15 +235,15 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
     }
 
     @Test
-    public void authorizedUser_shouldStoreMetadata_onlyRequiredByLicence() throws Exception {
-        this.prepareEnvironment("SEND_TOKEN,EXTRA_EMAIL", Confirmation.ALLOW_ANONYMOUS);
+    public void authorizedUser_manageUserMetadata_shouldStoreOnlyRequiredMetadata() throws Exception {
+        this.prepareEnvironment("SEND_TOKEN,EXTRA_EMAIL,NAME", Confirmation.ALLOW_ANONYMOUS);
         ObjectMapper mapper = new ObjectMapper();
         ClarinUserMetadataRest clarinUserMetadata1 = new ClarinUserMetadataRest();
         clarinUserMetadata1.setMetadataKey("NAME");
         clarinUserMetadata1.setMetadataValue("Test");
 
         ClarinUserMetadataRest clarinUserMetadata2 = new ClarinUserMetadataRest();
-        clarinUserMetadata2.setMetadataKey("NAME");
+        clarinUserMetadata2.setMetadataKey("ADDRESS");
         clarinUserMetadata2.setMetadataValue("Test2");
 
         ClarinUserMetadataRest clarinUserMetadata3 = new ClarinUserMetadataRest();
@@ -253,11 +253,16 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
         clarinUserMetadata4.setMetadataKey("EXTRA_EMAIL");
         clarinUserMetadata4.setMetadataValue("test@test.edu");
 
+        ClarinUserMetadataRest clarinUserMetadata5 = new ClarinUserMetadataRest();
+        clarinUserMetadata5.setMetadataKey("ORGANIZATION");
+        clarinUserMetadata5.setMetadataValue("organization");
+
         List<ClarinUserMetadataRest> clarinUserMetadataRestList = new ArrayList<>();
         clarinUserMetadataRestList.add(clarinUserMetadata1);
         clarinUserMetadataRestList.add(clarinUserMetadata2);
         clarinUserMetadataRestList.add(clarinUserMetadata3);
         clarinUserMetadataRestList.add(clarinUserMetadata4);
+        clarinUserMetadataRestList.add(clarinUserMetadata5);
 
         String adminToken = getAuthToken(admin.getEmail(), password);
         // Load bitstream from the item.
@@ -275,7 +280,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
                 .andExpect(jsonPath("$.page.totalElements", is(1)));
 
         // Get created User Metadata - there should be 2 records,
-        // because only 2 metadata fields are required by the license (SEND_TOKEN,EXTRA_EMAIL)
+        // because only 2 metadata fields are required by the license (EXTRA_EMAIL and ADDRESS)
         getClient(adminToken).perform(get("/api/core/clarinusermetadata")
                         .contentType(contentType))
                 .andExpect(status().isOk())
@@ -283,8 +288,84 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
     }
 
     @Test
-    public void authorizedUser_withMissingRequiredKeys_shouldFail() throws Exception {
-        this.prepareEnvironment("SEND_TOKEN,EXTRA_EMAIL,ADDRESS", Confirmation.ALLOW_ANONYMOUS);
+    public void authorizedUser_manageUserMetadata_organizationIsOptional() throws Exception {
+        this.prepareEnvironment("NAME,ORGANIZATION", Confirmation.ALLOW_ANONYMOUS);
+        ObjectMapper mapper = new ObjectMapper();
+        ClarinUserMetadataRest clarinUserMetadata1 = new ClarinUserMetadataRest();
+        clarinUserMetadata1.setMetadataKey("NAME");
+        clarinUserMetadata1.setMetadataValue("Test");
+
+        ClarinUserMetadataRest clarinUserMetadata2 = new ClarinUserMetadataRest();
+        clarinUserMetadata2.setMetadataKey("ADDRESS");
+        clarinUserMetadata2.setMetadataValue("Test2");
+
+        List<ClarinUserMetadataRest> clarinUserMetadataRestList = new ArrayList<>();
+        clarinUserMetadataRestList.add(clarinUserMetadata1);
+        clarinUserMetadataRestList.add(clarinUserMetadata2);
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        // Load bitstream from the item.
+        getClient().perform(post("/api/core/clarinusermetadata/manage?bitstreamUUID=" + bitstream.getID())
+                        .content(mapper.writeValueAsBytes(clarinUserMetadataRestList.toArray()))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", notNullValue()));
+
+        // Get created CLRUA
+        getClient(adminToken).perform(get("/api/core/clarinlruallowances")
+                        .contentType(contentType))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        // Get created User Metadata - only NAME metadata is stored,
+        // because ORGANIZATION metadata is empty and should not be stored
+        getClient(adminToken).perform(get("/api/core/clarinusermetadata")
+                        .contentType(contentType))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(1)));
+    }
+
+    @Test
+    public void authorizedUser_manageUserMetadata_shouldStoreOrganizationAndIP() throws Exception {
+        this.prepareEnvironment("ORGANIZATION", Confirmation.ALLOW_ANONYMOUS);
+        ObjectMapper mapper = new ObjectMapper();
+        ClarinUserMetadataRest clarinUserMetadata1 = new ClarinUserMetadataRest();
+        clarinUserMetadata1.setMetadataKey("ORGANIZATION");
+        clarinUserMetadata1.setMetadataValue("Test");
+
+        ClarinUserMetadataRest clarinUserMetadata2 = new ClarinUserMetadataRest();
+        clarinUserMetadata2.setMetadataKey("IP");
+        clarinUserMetadata2.setMetadataValue("127.0.0.1");
+
+        List<ClarinUserMetadataRest> clarinUserMetadataRestList = new ArrayList<>();
+        clarinUserMetadataRestList.add(clarinUserMetadata1);
+        clarinUserMetadataRestList.add(clarinUserMetadata2);
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        // Load bitstream from the item.
+        getClient().perform(post("/api/core/clarinusermetadata/manage?bitstreamUUID=" + bitstream.getID())
+                        .content(mapper.writeValueAsBytes(clarinUserMetadataRestList.toArray()))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", notNullValue()));
+
+        // Get created CLRUA
+        getClient(adminToken).perform(get("/api/core/clarinlruallowances")
+                        .contentType(contentType))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        // Get created User Metadata - only NAME metadata is stored,
+        // because ORGANIZATION metadata is empty and should not be stored
+        getClient(adminToken).perform(get("/api/core/clarinusermetadata")
+                        .contentType(contentType))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(2)));
+    }
+
+    @Test
+    public void authorizedUser_manageUserMetadata_withMissingRequiredKeys_shouldFail() throws Exception {
+        this.prepareEnvironment("SEND_TOKEN,EXTRA_EMAIL,REQUIRED_ORGANIZATION", Confirmation.ALLOW_ANONYMOUS);
         ObjectMapper mapper = new ObjectMapper();
 
         ClarinUserMetadataRest carinUserMetadata1 = new ClarinUserMetadataRest();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
@@ -283,6 +283,28 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
     }
 
     @Test
+    public void authorizedUser_withMissingRequiredKeys_shouldFail() throws Exception {
+        this.prepareEnvironment("SEND_TOKEN,EXTRA_EMAIL,ADDRESS", Confirmation.ALLOW_ANONYMOUS);
+        ObjectMapper mapper = new ObjectMapper();
+
+        ClarinUserMetadataRest carinUserMetadata1 = new ClarinUserMetadataRest();
+        carinUserMetadata1.setMetadataKey("SEND_TOKEN");
+
+        ClarinUserMetadataRest clarinUserMetadata2 = new ClarinUserMetadataRest();
+        clarinUserMetadata2.setMetadataKey("EXTRA_EMAIL");
+        clarinUserMetadata2.setMetadataValue("test@test.edu");
+
+        List<ClarinUserMetadataRest> clarinUserMetadataRestList = new ArrayList<>();
+        clarinUserMetadataRestList.add(carinUserMetadata1);
+        clarinUserMetadataRestList.add(clarinUserMetadata2);
+
+        getClient().perform(post("/api/core/clarinusermetadata/manage?bitstreamUUID=" + bitstream.getID())
+                        .content(mapper.writeValueAsBytes(clarinUserMetadataRestList.toArray()))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     public void authorizedUserWithoutMetadata_shouldReturnToken() throws Exception {
         this.prepareEnvironment("NAME", Confirmation.NOT_REQUIRED);
         context.turnOffAuthorisationSystem();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinUserMetadataRestControllerIT.java
@@ -186,7 +186,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
 
     @Test
     public void notAuthorizedUser_withAllowingAnonymousLicense_shouldSendEmail() throws Exception {
-        this.prepareEnvironment("SEND_TOKEN", Confirmation.ALLOW_ANONYMOUS);
+        this.prepareEnvironment("SEND_TOKEN,EXTRA_EMAIL", Confirmation.ALLOW_ANONYMOUS);
         ObjectMapper mapper = new ObjectMapper();
         ClarinUserMetadataRest clarinUserMetadata1 = new ClarinUserMetadataRest();
         clarinUserMetadata1.setMetadataKey("NAME");
@@ -232,6 +232,54 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
                         .content(new byte[0])
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void authorizedUser_shouldStoreMetadata_onlyRequiredByLicence() throws Exception {
+        this.prepareEnvironment("SEND_TOKEN,EXTRA_EMAIL", Confirmation.ALLOW_ANONYMOUS);
+        ObjectMapper mapper = new ObjectMapper();
+        ClarinUserMetadataRest clarinUserMetadata1 = new ClarinUserMetadataRest();
+        clarinUserMetadata1.setMetadataKey("NAME");
+        clarinUserMetadata1.setMetadataValue("Test");
+
+        ClarinUserMetadataRest clarinUserMetadata2 = new ClarinUserMetadataRest();
+        clarinUserMetadata2.setMetadataKey("NAME");
+        clarinUserMetadata2.setMetadataValue("Test2");
+
+        ClarinUserMetadataRest clarinUserMetadata3 = new ClarinUserMetadataRest();
+        clarinUserMetadata3.setMetadataKey("SEND_TOKEN");
+
+        ClarinUserMetadataRest clarinUserMetadata4 = new ClarinUserMetadataRest();
+        clarinUserMetadata4.setMetadataKey("EXTRA_EMAIL");
+        clarinUserMetadata4.setMetadataValue("test@test.edu");
+
+        List<ClarinUserMetadataRest> clarinUserMetadataRestList = new ArrayList<>();
+        clarinUserMetadataRestList.add(clarinUserMetadata1);
+        clarinUserMetadataRestList.add(clarinUserMetadata2);
+        clarinUserMetadataRestList.add(clarinUserMetadata3);
+        clarinUserMetadataRestList.add(clarinUserMetadata4);
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        // Load bitstream from the item.
+        getClient().perform(post("/api/core/clarinusermetadata/manage?bitstreamUUID=" + bitstream.getID())
+                        .content(mapper.writeValueAsBytes(clarinUserMetadataRestList.toArray()))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", notNullValue()))
+                .andExpect(jsonPath("$", is(CHECK_EMAIL_RESPONSE_CONTENT)));
+
+        // Get created CLRUA
+        getClient(adminToken).perform(get("/api/core/clarinlruallowances")
+                        .contentType(contentType))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        // Get created User Metadata - there should be 2 records,
+        // because only 2 metadata fields are required by the license (SEND_TOKEN,EXTRA_EMAIL)
+        getClient(adminToken).perform(get("/api/core/clarinusermetadata")
+                        .contentType(contentType))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(2)));
     }
 
     @Test
@@ -281,7 +329,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
 
     @Test
     public void authorizedUserWithoutMetadata_shouldSendEmail() throws Exception {
-        this.prepareEnvironment("SEND_TOKEN", Confirmation.NOT_REQUIRED);
+        this.prepareEnvironment("SEND_TOKEN,EXTRA_EMAIL", Confirmation.NOT_REQUIRED);
         context.turnOffAuthorisationSystem();
         ClarinUserRegistration clarinUserRegistration = ClarinUserRegistrationBuilder
                 .createClarinUserRegistration(context).withEPersonID(admin.getID()).build();
@@ -384,7 +432,7 @@ public class ClarinUserMetadataRestControllerIT extends AbstractControllerIntegr
 
     @Test
     public void authorizedUserWithMetadata_shouldSendEmail() throws Exception {
-        this.prepareEnvironment("SEND_TOKEN,NAME,ADDRESS", Confirmation.NOT_REQUIRED);
+        this.prepareEnvironment("SEND_TOKEN,NAME,ADDRESS,EXTRA_EMAIL", Confirmation.NOT_REQUIRED);
         context.turnOffAuthorisationSystem();
         ClarinUserRegistration clarinUserRegistration = ClarinUserRegistrationBuilder
                 .createClarinUserRegistration(context).withEPersonID(admin.getID()).build();


### PR DESCRIPTION
Resolving multiple problems with file-download, that requires License agreement:
- check whether manageUserMetadata payload contains all required metadata keys. Return error 400 otherwise
- handle empty payload in manageUserMetadata POST request - return 400 rather than Server error (500)
   (this issue is described here: https://github.com/ufal/clarin-dspace/issues/1228)
- filter the payload and store only metadata keys related to Clarin license (ignore other fields from the payload)
- handle specially the "required" metadata keys that are optional, e.g. ORGANIZATION(optional)