### PR TITLE
[wip] EPerson merge tooling

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/EPersonMerge.java
+++ b/dspace-api/src/main/java/org/dspace/administer/EPersonMerge.java
@@ -1,0 +1,93 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.administer;
+
+import java.util.UUID;
+
+import org.apache.commons.cli.ParseException;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.clarin.EPersonMergeAudit;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.EPersonService;
+import org.dspace.eperson.service.clarin.EPersonMergeService;
+import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.utils.DSpace;
+
+/**
+ * Merges two EPerson accounts that turned out to be duplicates of the same human: re-points
+ * foreign keys from {@code --from} to {@code --to}, unions/dedupes memberships, tombstones the
+ * {@code from} account (disabled, never deleted) and records an audit trail. Does not rewrite
+ * item metadata/provenance.
+ *
+ * @author Ondrej Kosarko
+ */
+public class EPersonMerge extends DSpaceRunnable<EPersonMergeConfiguration<EPersonMerge>> {
+
+    private EPersonService ePersonService;
+    private EPersonMergeService ePersonMergeService;
+
+    private UUID fromUuid;
+    private UUID toUuid;
+    private boolean help = false;
+
+    @Override
+    public void setup() throws ParseException {
+        this.ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
+        this.ePersonMergeService = EPersonServiceFactory.getInstance().getEPersonMergeService();
+
+        this.help = commandLine.hasOption('h');
+        if (this.help) {
+            return;
+        }
+
+        try {
+            this.fromUuid = UUID.fromString(commandLine.getOptionValue('f'));
+            this.toUuid = UUID.fromString(commandLine.getOptionValue('t'));
+        } catch (IllegalArgumentException e) {
+            throw new ParseException("--from and --to must both be valid EPerson UUIDs");
+        }
+    }
+
+    @Override
+    public void internalRun() throws Exception {
+        if (help) {
+            printHelp();
+            return;
+        }
+
+        Context context = new Context();
+        context.setCurrentUser(ePersonService.find(context, getEpersonIdentifier()));
+
+        try {
+            context.turnOffAuthorisationSystem();
+
+            EPerson from = ePersonService.find(context, fromUuid);
+            if (from == null) {
+                throw new IllegalArgumentException("No EPerson found for --from " + fromUuid);
+            }
+            EPerson to = ePersonService.find(context, toUuid);
+            if (to == null) {
+                throw new IllegalArgumentException("No EPerson found for --to " + toUuid);
+            }
+
+            EPersonMergeAudit audit = ePersonMergeService.merge(context, from, to, context.getCurrentUser());
+            handler.logInfo("Merged EPerson " + fromUuid + " into " + toUuid + ": " + audit.getDetail());
+        } finally {
+            context.restoreAuthSystemState();
+            context.complete();
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public EPersonMergeConfiguration<EPersonMerge> getScriptConfiguration() {
+        return new DSpace().getServiceManager()
+            .getServiceByName("eperson-merge", EPersonMergeConfiguration.class);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/administer/EPersonMerge.java
+++ b/dspace-api/src/main/java/org/dspace/administer/EPersonMerge.java
@@ -7,9 +7,11 @@
  */
 package org.dspace.administer;
 
+import java.sql.SQLException;
 import java.util.UUID;
 
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.clarin.EPersonMergeAudit;
@@ -34,6 +36,7 @@ public class EPersonMerge extends DSpaceRunnable<EPersonMergeConfiguration<EPers
 
     private UUID fromUuid;
     private UUID toUuid;
+    private String epersonEmail;
     private boolean help = false;
 
     @Override
@@ -52,6 +55,8 @@ public class EPersonMerge extends DSpaceRunnable<EPersonMergeConfiguration<EPers
         } catch (IllegalArgumentException e) {
             throw new ParseException("--from and --to must both be valid EPerson UUIDs");
         }
+
+        this.epersonEmail = commandLine.getOptionValue('e');
     }
 
     @Override
@@ -62,7 +67,7 @@ public class EPersonMerge extends DSpaceRunnable<EPersonMergeConfiguration<EPers
         }
 
         Context context = new Context();
-        context.setCurrentUser(ePersonService.find(context, getEpersonIdentifier()));
+        context.setCurrentUser(getPerformingEPerson(context));
 
         try {
             context.turnOffAuthorisationSystem();
@@ -89,5 +94,24 @@ public class EPersonMerge extends DSpaceRunnable<EPersonMergeConfiguration<EPers
     public EPersonMergeConfiguration<EPersonMerge> getScriptConfiguration() {
         return new DSpace().getServiceManager()
             .getServiceByName("eperson-merge", EPersonMergeConfiguration.class);
+    }
+
+    /**
+     * Resolve the admin EPerson performing this merge, for the audit trail: the REST-invoked
+     * current user if there is one, otherwise the CLI {@code -e/--eperson} email if provided,
+     * otherwise null (unattributed run).
+     */
+    private EPerson getPerformingEPerson(Context context) throws SQLException {
+        if (getEpersonIdentifier() != null) {
+            return ePersonService.find(context, getEpersonIdentifier());
+        }
+        if (StringUtils.isNotBlank(epersonEmail)) {
+            EPerson eperson = ePersonService.findByEmail(context, epersonEmail);
+            if (eperson == null) {
+                throw new IllegalArgumentException("No EPerson found for --eperson " + epersonEmail);
+            }
+            return eperson;
+        }
+        return null;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/administer/EPersonMerge.java
+++ b/dspace-api/src/main/java/org/dspace/administer/EPersonMerge.java
@@ -83,9 +83,11 @@ public class EPersonMerge extends DSpaceRunnable<EPersonMergeConfiguration<EPers
 
             EPersonMergeAudit audit = ePersonMergeService.merge(context, from, to, context.getCurrentUser());
             handler.logInfo("Merged EPerson " + fromUuid + " into " + toUuid + ": " + audit.getDetail());
-        } finally {
             context.restoreAuthSystemState();
             context.complete();
+        } catch (Exception e) {
+            context.abort();
+            throw e;
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/administer/EPersonMergeCli.java
+++ b/dspace-api/src/main/java/org/dspace/administer/EPersonMergeCli.java
@@ -1,0 +1,17 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.administer;
+
+/**
+ * The {@link EPersonMerge} for CLI.
+ *
+ * @author Ondrej Kosarko
+ */
+public class EPersonMergeCli extends EPersonMerge {
+
+}

--- a/dspace-api/src/main/java/org/dspace/administer/EPersonMergeCliConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/administer/EPersonMergeCliConfiguration.java
@@ -1,0 +1,17 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.administer;
+
+/**
+ * The {@link EPersonMergeConfiguration} for CLI.
+ *
+ * @author Ondrej Kosarko
+ */
+public class EPersonMergeCliConfiguration extends EPersonMergeConfiguration<EPersonMergeCli> {
+
+}

--- a/dspace-api/src/main/java/org/dspace/administer/EPersonMergeConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/administer/EPersonMergeConfiguration.java
@@ -1,0 +1,55 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.administer;
+
+import org.apache.commons.cli.Options;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+
+/**
+ * The {@link ScriptConfiguration} for the {@link EPersonMerge} script. Restricted to admins by
+ * the {@link ScriptConfiguration} default {@code isAllowedToExecute}.
+ *
+ * @author Ondrej Kosarko
+ */
+public class EPersonMergeConfiguration<T extends EPersonMerge> extends ScriptConfiguration<T> {
+
+    private Class<T> dspaceRunnableClass;
+
+    @Override
+    public Options getOptions() {
+        if (options == null) {
+            Options options = new Options();
+
+            options.addOption("h", "help", false, "help");
+
+            options.addOption("f", "from", true,
+                "UUID of the EPerson to merge away (tombstoned - disabled, not deleted)");
+            options.getOption("f").setRequired(true);
+
+            options.addOption("t", "to", true, "UUID of the EPerson to merge into (the surviving account)");
+            options.getOption("t").setRequired(true);
+
+            options.addOption("e", "eperson", true,
+                "email of the admin EPerson performing the merge (recorded in the audit trail)");
+
+            super.options = options;
+        }
+        return options;
+    }
+
+    @Override
+    public Class<T> getDspaceRunnableClass() {
+        return dspaceRunnableClass;
+    }
+
+    @Override
+    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
+        this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/content/clarin/MatomoReportSubscriptionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/MatomoReportSubscriptionServiceImpl.java
@@ -8,7 +8,10 @@
 package org.dspace.content.clarin;
 
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import javax.ws.rs.BadRequestException;
 
 import org.dspace.authorize.AuthorizeException;
@@ -113,16 +116,23 @@ public class MatomoReportSubscriptionServiceImpl implements MatomoReportSubscrip
 
     @Override
     public int reassignEPerson(Context context, EPerson from, EPerson to) throws SQLException {
+        Set<UUID> toItemIds = new HashSet<>();
+        for (MatomoReportSubscription subscription : matomoReportSubscriptionDAO.findByEPersonId(context,
+                to.getID())) {
+            toItemIds.add(subscription.getItem().getID());
+        }
+
         int count = 0;
         for (MatomoReportSubscription subscription : matomoReportSubscriptionDAO.findByEPersonId(context,
                 from.getID())) {
-            if (matomoReportSubscriptionDAO.findByEPersonIdAndItemId(context, to.getID(),
-                    subscription.getItem().getID()) != null) {
+            UUID itemId = subscription.getItem().getID();
+            if (toItemIds.contains(itemId)) {
                 // `to` is already subscribed to this item - drop the duplicate.
                 matomoReportSubscriptionDAO.delete(context, subscription);
             } else {
                 subscription.setEPerson(to);
                 matomoReportSubscriptionDAO.save(context, subscription);
+                toItemIds.add(itemId);
                 count++;
             }
         }

--- a/dspace-api/src/main/java/org/dspace/content/clarin/MatomoReportSubscriptionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/clarin/MatomoReportSubscriptionServiceImpl.java
@@ -18,6 +18,7 @@ import org.dspace.content.dao.ItemDAO;
 import org.dspace.content.dao.clarin.MatomoReportSubscriptionDAO;
 import org.dspace.content.service.clarin.MatomoReportSubscriptionService;
 import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -108,5 +109,23 @@ public class MatomoReportSubscriptionServiceImpl implements MatomoReportSubscrip
             throw new AuthorizeException("You must be authenticated user");
         }
         return (matomoReportSubscriptionDAO.findByItemIdAndCurrentUser(context, item.getID()) != null);
+    }
+
+    @Override
+    public int reassignEPerson(Context context, EPerson from, EPerson to) throws SQLException {
+        int count = 0;
+        for (MatomoReportSubscription subscription : matomoReportSubscriptionDAO.findByEPersonId(context,
+                from.getID())) {
+            if (matomoReportSubscriptionDAO.findByEPersonIdAndItemId(context, to.getID(),
+                    subscription.getItem().getID()) != null) {
+                // `to` is already subscribed to this item - drop the duplicate.
+                matomoReportSubscriptionDAO.delete(context, subscription);
+            } else {
+                subscription.setEPerson(to);
+                matomoReportSubscriptionDAO.save(context, subscription);
+                count++;
+            }
+        }
+        return count;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/service/clarin/MatomoReportSubscriptionService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/clarin/MatomoReportSubscriptionService.java
@@ -14,6 +14,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Item;
 import org.dspace.content.clarin.MatomoReportSubscription;
 import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
 
 /**
  * Service interface class for the MatomoReportSubscription object.
@@ -79,5 +80,17 @@ public interface MatomoReportSubscriptionService {
      * @throws AuthorizeException the user in not admin
      */
     List<MatomoReportSubscription> findAll(Context context) throws SQLException, AuthorizeException;
+
+    /**
+     * Re-point all of {@code from}'s subscriptions to {@code to} (used by {@code eperson-merge}), dropping
+     * any that would duplicate a subscription {@code to} already has for the same item.
+     *
+     * @param context DSpace context object
+     * @param from EPerson whose subscriptions are being moved
+     * @param to EPerson receiving the subscriptions
+     * @return the number of subscriptions actually re-pointed (not counting dropped duplicates)
+     * @throws SQLException if database error
+     */
+    int reassignEPerson(Context context, EPerson from, EPerson to) throws SQLException;
 
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/clarin/EPersonMergeAudit.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/clarin/EPersonMergeAudit.java
@@ -1,0 +1,108 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.eperson.clarin;
+
+import java.util.Date;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import org.dspace.core.ReloadableEntity;
+
+/**
+ * Audit trail for {@code eperson-merge}: from/to are kept as plain UUIDs (not
+ * FKs) so the record survives even if an EPerson is later deleted outright.
+ * {@code detail} is a JSON blob with per-table re-pointed row counts and tool
+ * version, making every merge reconstructible.
+ *
+ * @author Ondrej Kosarko
+ */
+@Entity
+@Table(name = "eperson_merge_audit")
+public class EPersonMergeAudit implements ReloadableEntity<Integer> {
+
+    @Id
+    @Column(name = "eperson_merge_audit_id")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eperson_merge_audit_id_seq")
+    @SequenceGenerator(name = "eperson_merge_audit_id_seq", sequenceName = "eperson_merge_audit_id_seq",
+            allocationSize = 1)
+    private Integer id;
+
+    @Column(name = "from_eperson", nullable = false)
+    private UUID fromEPerson;
+
+    @Column(name = "to_eperson", nullable = false)
+    private UUID toEPerson;
+
+    @Column(name = "performed_by")
+    private UUID performedBy;
+
+    @Column(name = "performed_at", nullable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date performedAt;
+
+    @Lob
+    @Column(name = "detail", nullable = false)
+    private String detail;
+
+    protected EPersonMergeAudit() {
+    }
+
+    @Override
+    public Integer getID() {
+        return id;
+    }
+
+    public UUID getFromEPerson() {
+        return fromEPerson;
+    }
+
+    public void setFromEPerson(UUID fromEPerson) {
+        this.fromEPerson = fromEPerson;
+    }
+
+    public UUID getToEPerson() {
+        return toEPerson;
+    }
+
+    public void setToEPerson(UUID toEPerson) {
+        this.toEPerson = toEPerson;
+    }
+
+    public UUID getPerformedBy() {
+        return performedBy;
+    }
+
+    public void setPerformedBy(UUID performedBy) {
+        this.performedBy = performedBy;
+    }
+
+    public Date getPerformedAt() {
+        return performedAt;
+    }
+
+    public void setPerformedAt(Date performedAt) {
+        this.performedAt = performedAt;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public void setDetail(String detail) {
+        this.detail = detail;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/eperson/clarin/EPersonMergeAuditServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/clarin/EPersonMergeAuditServiceImpl.java
@@ -1,0 +1,48 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.eperson.clarin;
+
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dspace.core.Context;
+import org.dspace.eperson.dao.clarin.EPersonMergeAuditDAO;
+import org.dspace.eperson.service.clarin.EPersonMergeAuditService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @see EPersonMergeAuditService
+ *
+ * @author Ondrej Kosarko
+ */
+public class EPersonMergeAuditServiceImpl implements EPersonMergeAuditService {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    private EPersonMergeAuditDAO ePersonMergeAuditDAO;
+
+    @Override
+    public EPersonMergeAudit record(Context context, UUID fromEPerson, UUID toEPerson, UUID performedBy,
+            Map<String, Object> detail) throws SQLException {
+        EPersonMergeAudit audit = new EPersonMergeAudit();
+        audit.setFromEPerson(fromEPerson);
+        audit.setToEPerson(toEPerson);
+        audit.setPerformedBy(performedBy);
+        audit.setPerformedAt(new Date());
+        try {
+            audit.setDetail(objectMapper.writeValueAsString(detail));
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to serialize merge audit detail", e);
+        }
+        return ePersonMergeAuditDAO.create(context, audit);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/eperson/clarin/EPersonMergeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/clarin/EPersonMergeServiceImpl.java
@@ -1,0 +1,429 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.eperson.clarin;
+
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.Item;
+import org.dspace.content.clarin.ClarinUserRegistration;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.clarin.ClarinTokenService;
+import org.dspace.content.service.clarin.ClarinUserRegistrationService;
+import org.dspace.content.service.clarin.MatomoReportSubscriptionService;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.Subscription;
+import org.dspace.eperson.dao.GroupDAO;
+import org.dspace.eperson.dao.SubscriptionDAO;
+import org.dspace.eperson.dao.clarin.EPersonNetidAliasDAO;
+import org.dspace.eperson.service.EPersonService;
+import org.dspace.eperson.service.GroupService;
+import org.dspace.eperson.service.SubscribeService;
+import org.dspace.eperson.service.clarin.ClarinIdentityService;
+import org.dspace.eperson.service.clarin.EPersonMergeAuditService;
+import org.dspace.eperson.service.clarin.EPersonMergeService;
+import org.dspace.orcid.OrcidToken;
+import org.dspace.orcid.service.OrcidTokenService;
+import org.dspace.scripts.Process;
+import org.dspace.scripts.service.ProcessService;
+import org.dspace.versioning.Version;
+import org.dspace.versioning.service.VersioningService;
+import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
+import org.dspace.xmlworkflow.storedcomponents.InProgressUser;
+import org.dspace.xmlworkflow.storedcomponents.PoolTask;
+import org.dspace.xmlworkflow.storedcomponents.WorkflowItemRole;
+import org.dspace.xmlworkflow.storedcomponents.service.ClaimedTaskService;
+import org.dspace.xmlworkflow.storedcomponents.service.InProgressUserService;
+import org.dspace.xmlworkflow.storedcomponents.service.PoolTaskService;
+import org.dspace.xmlworkflow.storedcomponents.service.WorkflowItemRoleService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @see EPersonMergeService
+ *
+ * @author Ondrej Kosarko
+ */
+public class EPersonMergeServiceImpl implements EPersonMergeService {
+
+    private static final Logger log = LogManager.getLogger(EPersonMergeServiceImpl.class);
+
+    public static final String TOOL_VERSION = "1";
+
+    /**
+     * Matches the {@code length} constraint on the {@code eperson.email} column
+     * ({@link org.dspace.eperson.EPerson#getEmail()}).
+     */
+    private static final int EMAIL_MAX_LENGTH = 64;
+
+    @Autowired
+    private EPersonService ePersonService;
+    @Autowired
+    private ItemService itemService;
+    @Autowired
+    private ResourcePolicyService resourcePolicyService;
+    @Autowired
+    private GroupDAO groupDAO;
+    @Autowired
+    private GroupService groupService;
+    @Autowired
+    private WorkflowItemRoleService workflowItemRoleService;
+    @Autowired
+    private PoolTaskService poolTaskService;
+    @Autowired
+    private ClaimedTaskService claimedTaskService;
+    @Autowired
+    private InProgressUserService inProgressUserService;
+    @Autowired
+    private SubscribeService subscribeService;
+    @Autowired
+    private SubscriptionDAO subscriptionDAO;
+    @Autowired
+    private ProcessService processService;
+    @Autowired
+    private VersioningService versioningService;
+    @Autowired
+    private OrcidTokenService orcidTokenService;
+    @Autowired
+    private ClarinTokenService clarinTokenService;
+    @Autowired
+    private MatomoReportSubscriptionService matomoReportSubscriptionService;
+    @Autowired
+    private ClarinUserRegistrationService clarinUserRegistrationService;
+    @Autowired
+    private ClarinIdentityService identityService;
+    @Autowired
+    private EPersonNetidAliasDAO ePersonNetidAliasDAO;
+    @Autowired
+    private EPersonMergeAuditService ePersonMergeAuditService;
+
+    @Override
+    public EPersonMergeAudit merge(Context context, EPerson from, EPerson to, EPerson performedBy)
+            throws SQLException, AuthorizeException {
+        if (Objects.equals(from.getID(), to.getID())) {
+            throw new IllegalArgumentException("Cannot merge an EPerson into itself: " + from.getID());
+        }
+
+        Map<String, Object> detail = new LinkedHashMap<>();
+        detail.put("toolVersion", TOOL_VERSION);
+        detail.put("fromEmail", from.getEmail());
+        detail.put("toEmail", to.getEmail());
+
+        detail.put("item.submitter", reassignItemSubmitter(context, from, to));
+        detail.put("resourcepolicy", reassignResourcePolicies(context, from, to));
+        detail.put("group2eperson", reassignGroupMembership(context, from, to));
+        detail.put("cwf_workflowitemrole", reassignWorkflowItemRoles(context, from, to));
+        detail.put("cwf_pooltask", reassignPoolTasks(context, from, to));
+        detail.put("cwf_claimtask", reassignClaimedTasks(context, from, to));
+        detail.put("cwf_in_progress_user", reassignInProgressUsers(context, from, to));
+        detail.put("subscription", reassignSubscriptions(context, from, to));
+        detail.put("process", reassignProcesses(context, from, to));
+        detail.put("versionitem", reassignVersions(context, from, to));
+        detail.put("orcid_token", reassignOrcidToken(context, from, to));
+        detail.put("clarin_token_deleted", deleteClarinTokens(context, from));
+        detail.put("matomo_report_subscription", reassignMatomoSubscriptions(context, from, to));
+        detail.put("user_registration", reassignUserRegistrations(context, from, to));
+        detail.put("alias", reassignAliases(context, from, to));
+        // supervision_order references only an epersongroup, not an eperson directly - any
+        // membership `from` held in a supervision group was already moved by the group2eperson step.
+
+        String parkedEmail = tombstone(context, from, to);
+        detail.put("fromEmailParkedAs", parkedEmail);
+
+        EPersonMergeAudit audit = ePersonMergeAuditService.record(context, from.getID(), to.getID(),
+                performedBy == null ? null : performedBy.getID(), detail);
+
+        log.info("Merged EPerson {} into {} (performed by {}): {}", from.getID(), to.getID(),
+                performedBy == null ? "system" : performedBy.getID(), detail);
+
+        return audit;
+    }
+
+    private int reassignItemSubmitter(Context context, EPerson from, EPerson to) throws SQLException {
+        int count = 0;
+        Iterator<Item> items = itemService.findBySubmitter(context, from);
+        while (items.hasNext()) {
+            Item item = items.next();
+            item.setSubmitter(to);
+            try {
+                itemService.update(context, item);
+            } catch (AuthorizeException e) {
+                throw new IllegalStateException(e);
+            }
+            count++;
+        }
+        return count;
+    }
+
+    /**
+     * Re-points resourcepolicy rows, skipping (leaving attached to the tombstoned `from`) any
+     * that would duplicate a policy `to` already holds for the same resource/action/type.
+     */
+    private int reassignResourcePolicies(Context context, EPerson from, EPerson to) throws SQLException {
+        List<ResourcePolicy> toPolicies = resourcePolicyService.findByEPerson(context, to, -1, -1);
+        Set<String> toSignatures = new HashSet<>();
+        for (ResourcePolicy rp : toPolicies) {
+            toSignatures.add(resourcePolicySignature(rp));
+        }
+
+        int count = 0;
+        for (ResourcePolicy rp : resourcePolicyService.findByEPerson(context, from, -1, -1)) {
+            if (toSignatures.contains(resourcePolicySignature(rp))) {
+                continue;
+            }
+            rp.setEPerson(to);
+            try {
+                resourcePolicyService.update(context, rp);
+            } catch (AuthorizeException e) {
+                throw new IllegalStateException(e);
+            }
+            count++;
+        }
+        return count;
+    }
+
+    private static String resourcePolicySignature(ResourcePolicy rp) {
+        return rp.getdSpaceObject().getID() + "|" + rp.getAction() + "|" + rp.getRpType() + "|"
+                + rp.getStartDate() + "|" + rp.getEndDate() + "|" + rp.getRpName() + "|" + rp.getRpDescription();
+    }
+
+    private int reassignGroupMembership(Context context, EPerson from, EPerson to) throws SQLException {
+        int count = 0;
+        for (Group group : groupDAO.findByEPerson(context, from)) {
+            if (!groupService.isDirectMember(group, to)) {
+                groupService.addMember(context, group, to);
+            }
+            groupService.removeMember(context, group, from);
+            count++;
+        }
+        return count;
+    }
+
+    private int reassignWorkflowItemRoles(Context context, EPerson from, EPerson to)
+            throws SQLException, AuthorizeException {
+        int count = 0;
+        for (WorkflowItemRole role : workflowItemRoleService.findByEPerson(context, from)) {
+            role.setEPerson(to);
+            workflowItemRoleService.update(context, role);
+            count++;
+        }
+        return count;
+    }
+
+    private int reassignPoolTasks(Context context, EPerson from, EPerson to) throws SQLException, AuthorizeException {
+        int count = 0;
+        for (PoolTask task : poolTaskService.findByEPerson(context, from)) {
+            task.setEperson(to);
+            poolTaskService.update(context, task);
+            count++;
+        }
+        return count;
+    }
+
+    private int reassignClaimedTasks(Context context, EPerson from, EPerson to)
+            throws SQLException, AuthorizeException {
+        int count = 0;
+        for (ClaimedTask task : claimedTaskService.findByEperson(context, from)) {
+            task.setOwner(to);
+            claimedTaskService.update(context, task);
+            count++;
+        }
+        return count;
+    }
+
+    /**
+     * Skips (leaves with the tombstoned `from`) any in-progress-user row that would duplicate
+     * one `to` already has for the same workflow item (unique constraint on workflowitem+user).
+     */
+    private int reassignInProgressUsers(Context context, EPerson from, EPerson to)
+            throws SQLException, AuthorizeException {
+        Set<Integer> toWorkflowItems = new HashSet<>();
+        for (InProgressUser inProgressUser : inProgressUserService.findByEperson(context, to)) {
+            toWorkflowItems.add(inProgressUser.getWorkflowItem().getID());
+        }
+
+        int count = 0;
+        for (InProgressUser inProgressUser : inProgressUserService.findByEperson(context, from)) {
+            if (toWorkflowItems.contains(inProgressUser.getWorkflowItem().getID())) {
+                continue;
+            }
+            inProgressUser.setUser(to);
+            inProgressUserService.update(context, inProgressUser);
+            count++;
+        }
+        return count;
+    }
+
+    private int reassignSubscriptions(Context context, EPerson from, EPerson to) throws SQLException {
+        int count = 0;
+        for (Subscription subscription : subscribeService.findSubscriptionsByEPerson(context, from, -1, -1)) {
+            if (subscribeService.isSubscribed(context, to, subscription.getDSpaceObject())) {
+                subscribeService.deleteSubscription(context, subscription);
+                continue;
+            }
+            subscription.setEPerson(to);
+            subscriptionDAO.save(context, subscription);
+            count++;
+        }
+        return count;
+    }
+
+    private int reassignProcesses(Context context, EPerson from, EPerson to) throws SQLException {
+        int count = 0;
+        for (Process process : processService.findByUser(context, from, -1, -1)) {
+            process.setEPerson(to);
+            processService.update(context, process);
+            count++;
+        }
+        return count;
+    }
+
+    private int reassignVersions(Context context, EPerson from, EPerson to) throws SQLException {
+        int count = 0;
+        for (Version version : versioningService.findByEPerson(context, from)) {
+            version.setePerson(to);
+            versioningService.update(context, version);
+            count++;
+        }
+        return count;
+    }
+
+    /**
+     * orcid_token has a unique constraint on eperson_id: keep `to`'s token if it already has
+     * one, otherwise move `from`'s token across.
+     */
+    private int reassignOrcidToken(Context context, EPerson from, EPerson to) {
+        OrcidToken fromToken = orcidTokenService.findByEPerson(context, from);
+        if (fromToken == null) {
+            return 0;
+        }
+        if (orcidTokenService.findByEPerson(context, to) == null) {
+            orcidTokenService.create(context, to, fromToken.getProfileItem(), fromToken.getAccessToken());
+        }
+        orcidTokenService.delete(context, fromToken);
+        return 1;
+    }
+
+    /**
+     * clarin_token is a short-lived JWT-style auth/linking token, not identity data - dropping
+     * it is simpler and safer than trying to re-point it, since it will simply be re-issued the
+     * next time the merged (`to`) account needs one.
+     */
+    private boolean deleteClarinTokens(Context context, EPerson from) throws SQLException {
+        try {
+            clarinTokenService.delete(context, from);
+        } catch (AuthorizeException e) {
+            throw new IllegalStateException(e);
+        }
+        return true;
+    }
+
+    private int reassignMatomoSubscriptions(Context context, EPerson from, EPerson to) throws SQLException {
+        return matomoReportSubscriptionService.reassignEPerson(context, from, to);
+    }
+
+    /**
+     * user_registration keeps all rows (it carries per-organization license-agreement history) -
+     * every row simply follows the merged account.
+     */
+    private int reassignUserRegistrations(Context context, EPerson from, EPerson to) throws SQLException {
+        int count = 0;
+        try {
+            for (ClarinUserRegistration registration :
+                    clarinUserRegistrationService.findByEPersonUUID(context, from.getID())) {
+                registration.setPersonID(to.getID());
+                clarinUserRegistrationService.update(context, registration);
+                count++;
+            }
+        } catch (AuthorizeException e) {
+            throw new IllegalStateException(e);
+        }
+        return count;
+    }
+
+    private int reassignAliases(Context context, EPerson from, EPerson to) throws SQLException {
+        int count = 0;
+        for (EPersonNetidAlias alias : identityService.findAliases(context, from)) {
+            alias.setEPerson(to);
+            alias.setSource(ClarinIdentityService.SOURCE_MERGE);
+            ePersonNetidAliasDAO.save(context, alias);
+            count++;
+        }
+        return count;
+    }
+
+    /**
+     * Tombstone the `from` account: it is never deleted, only disabled. Its (denormalized)
+     * netid column is left untouched (R4: no rewriting beyond what merge requires), its email
+     * is parked to free the unique constraint for `to`, should an admin want it later.
+     */
+    private String tombstone(Context context, EPerson from, EPerson to) throws SQLException {
+        from.setCanLogIn(false);
+        String originalEmail = from.getEmail();
+        String parkedEmail = StringUtils.isBlank(originalEmail) ? null : buildParkedEmail(from, originalEmail);
+        if (parkedEmail != null) {
+            from.setEmail(parkedEmail);
+        }
+        try {
+            ePersonService.update(context, from);
+        } catch (AuthorizeException e) {
+            throw new IllegalStateException(e);
+        }
+        return parkedEmail;
+    }
+
+    /**
+     * Builds a "parked" email for the tombstoned account: {@code merged-<8charsOfId>+<originalEmail>}.
+     * The {@code email} column is limited to {@value #EMAIL_MAX_LENGTH} characters, so when the
+     * original email is long enough to overflow that limit, the local part (before the last
+     * {@code @}) is truncated and a short hash of the full original email is appended to keep the
+     * result unique and still traceable back to the original address.
+     */
+    private String buildParkedEmail(EPerson from, String originalEmail) {
+        String prefix = "merged-" + from.getID().toString().substring(0, 8) + "+";
+        String candidate = prefix + originalEmail;
+        if (candidate.length() <= EMAIL_MAX_LENGTH) {
+            return candidate;
+        }
+
+        String hash = Integer.toHexString(originalEmail.hashCode());
+        int atIndex = originalEmail.lastIndexOf('@');
+        String domain = atIndex >= 0 ? originalEmail.substring(atIndex) : "";
+        String localPart = atIndex >= 0 ? originalEmail.substring(0, atIndex) : originalEmail;
+
+        // Reserve space for the prefix, the hash marker and the domain, truncate the local part
+        // with whatever budget remains so the whole address stays within EMAIL_MAX_LENGTH.
+        String hashMarker = "~" + hash;
+        int budgetForLocalPart = EMAIL_MAX_LENGTH - prefix.length() - hashMarker.length() - domain.length();
+        if (budgetForLocalPart < 0) {
+            budgetForLocalPart = 0;
+        }
+        String truncatedLocalPart = localPart.length() > budgetForLocalPart
+                ? localPart.substring(0, budgetForLocalPart) : localPart;
+
+        String parkedEmail = prefix + truncatedLocalPart + hashMarker + domain;
+        if (parkedEmail.length() > EMAIL_MAX_LENGTH) {
+            // Extreme edge case (e.g. very long domain): hard-truncate as a last resort.
+            parkedEmail = parkedEmail.substring(0, EMAIL_MAX_LENGTH);
+        }
+        return parkedEmail;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/eperson/clarin/EPersonMergeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/clarin/EPersonMergeServiceImpl.java
@@ -175,7 +175,10 @@ public class EPersonMergeServiceImpl implements EPersonMergeService {
 
     /**
      * Re-points resourcepolicy rows, skipping (leaving attached to the tombstoned `from`) any
-     * that would duplicate a policy `to` already holds for the same resource/action/type.
+     * that would duplicate a policy `to` already holds. Duplicate means the full policy
+     * signature matches - resource, action, type, start/end dates, rpName and rpDescription,
+     * i.e. the fields {@link ResourcePolicy#equals} treats as significant - so if `from` itself
+     * holds two policies with an identical signature, only the first of them is moved.
      */
     private int reassignResourcePolicies(Context context, EPerson from, EPerson to) throws SQLException {
         List<ResourcePolicy> toPolicies = resourcePolicyService.findByEPerson(context, to, -1, -1);
@@ -186,7 +189,8 @@ public class EPersonMergeServiceImpl implements EPersonMergeService {
 
         int count = 0;
         for (ResourcePolicy rp : resourcePolicyService.findByEPerson(context, from, -1, -1)) {
-            if (toSignatures.contains(resourcePolicySignature(rp))) {
+            String sig = resourcePolicySignature(rp);
+            if (toSignatures.contains(sig)) {
                 continue;
             }
             rp.setEPerson(to);
@@ -195,6 +199,7 @@ public class EPersonMergeServiceImpl implements EPersonMergeService {
             } catch (AuthorizeException e) {
                 throw new IllegalStateException(e);
             }
+            toSignatures.add(sig);
             count++;
         }
         return count;

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/clarin/EPersonMergeAuditDAO.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/clarin/EPersonMergeAuditDAO.java
@@ -1,0 +1,19 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.eperson.dao.clarin;
+
+import org.dspace.core.GenericDAO;
+import org.dspace.eperson.clarin.EPersonMergeAudit;
+
+/**
+ * Database Access Object interface class for the EPersonMergeAudit object.
+ *
+ * @author Ondrej Kosarko
+ */
+public interface EPersonMergeAuditDAO extends GenericDAO<EPersonMergeAudit> {
+}

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/clarin/EPersonMergeAuditDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/clarin/EPersonMergeAuditDAOImpl.java
@@ -1,0 +1,21 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.eperson.dao.impl.clarin;
+
+import org.dspace.core.AbstractHibernateDAO;
+import org.dspace.eperson.clarin.EPersonMergeAudit;
+import org.dspace.eperson.dao.clarin.EPersonMergeAuditDAO;
+
+/**
+ * Database Access Object implementation class for the EPersonMergeAudit object.
+ *
+ * @author Ondrej Kosarko
+ */
+public class EPersonMergeAuditDAOImpl extends AbstractHibernateDAO<EPersonMergeAudit>
+        implements EPersonMergeAuditDAO {
+}

--- a/dspace-api/src/main/java/org/dspace/eperson/factory/EPersonServiceFactory.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/factory/EPersonServiceFactory.java
@@ -13,6 +13,7 @@ import org.dspace.eperson.service.GroupService;
 import org.dspace.eperson.service.RegistrationDataService;
 import org.dspace.eperson.service.SubscribeService;
 import org.dspace.eperson.service.clarin.ClarinIdentityService;
+import org.dspace.eperson.service.clarin.EPersonMergeService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
@@ -34,6 +35,8 @@ public abstract class EPersonServiceFactory {
     public abstract SubscribeService getSubscribeService();
 
     public abstract ClarinIdentityService getClarinIdentityService();
+
+    public abstract EPersonMergeService getEPersonMergeService();
 
     public static EPersonServiceFactory getInstance() {
         return DSpaceServicesFactory.getInstance().getServiceManager()

--- a/dspace-api/src/main/java/org/dspace/eperson/factory/EPersonServiceFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/factory/EPersonServiceFactoryImpl.java
@@ -13,6 +13,7 @@ import org.dspace.eperson.service.GroupService;
 import org.dspace.eperson.service.RegistrationDataService;
 import org.dspace.eperson.service.SubscribeService;
 import org.dspace.eperson.service.clarin.ClarinIdentityService;
+import org.dspace.eperson.service.clarin.EPersonMergeService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -35,6 +36,8 @@ public class EPersonServiceFactoryImpl extends EPersonServiceFactory {
     private SubscribeService subscribeService;
     @Autowired(required = true)
     private ClarinIdentityService clarinIdentityService;
+    @Autowired(required = true)
+    private EPersonMergeService ePersonMergeService;
 
     @Override
     public EPersonService getEPersonService() {
@@ -64,6 +67,11 @@ public class EPersonServiceFactoryImpl extends EPersonServiceFactory {
     @Override
     public ClarinIdentityService getClarinIdentityService() {
         return clarinIdentityService;
+    }
+
+    @Override
+    public EPersonMergeService getEPersonMergeService() {
+        return ePersonMergeService;
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/service/clarin/ClarinIdentityService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/clarin/ClarinIdentityService.java
@@ -47,6 +47,12 @@ public interface ClarinIdentityService {
     String SOURCE_ADMIN = "admin";
 
     /**
+     * Value persisted in {@code eperson_netid_alias.source} for aliases carried over onto the
+     * surviving EPerson by the {@code eperson-merge} tooling.
+     */
+    String SOURCE_MERGE = "merge";
+
+    /**
      * Resolve a formatted "value[authority]" netid to the EPerson it is aliased
      * to. Falls back to a legacy {@code EPerson.netid} column match when no
      * alias exists. Returns null if neither matches.

--- a/dspace-api/src/main/java/org/dspace/eperson/service/clarin/EPersonMergeAuditService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/clarin/EPersonMergeAuditService.java
@@ -1,0 +1,31 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.eperson.service.clarin;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.UUID;
+
+import org.dspace.core.Context;
+import org.dspace.eperson.clarin.EPersonMergeAudit;
+
+/**
+ * Records the audit trail for {@code eperson-merge}.
+ *
+ * @author Ondrej Kosarko
+ */
+public interface EPersonMergeAuditService {
+
+    /**
+     * Persist one merge audit record.
+     *
+     * @param detail per-table re-pointed row counts, moved netid/email, tool version
+     */
+    EPersonMergeAudit record(Context context, UUID fromEPerson, UUID toEPerson, UUID performedBy,
+        Map<String, Object> detail) throws SQLException;
+}

--- a/dspace-api/src/main/java/org/dspace/eperson/service/clarin/EPersonMergeService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/clarin/EPersonMergeService.java
@@ -1,0 +1,38 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.eperson.service.clarin;
+
+import java.sql.SQLException;
+
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.clarin.EPersonMergeAudit;
+
+/**
+ * Merges two EPerson accounts that turned out to be duplicates of the same
+ * human. Re-points foreign keys, unions/dedupes memberships, tombstones the
+ * {@code from} account (never deletes it) and writes an audit trail.
+ * Deliberately does NOT rewrite item metadata/provenance - historical
+ * {@code dc.description.provenance} keeps the old submitter identity, since
+ * it records what was true at the time.
+ *
+ * @author Ondrej Kosarko
+ */
+public interface EPersonMergeService {
+
+    /**
+     * Merge {@code from} into {@code to}.
+     *
+     * @param performedBy the admin EPerson running the merge (may be null for a system/CLI run
+     *      with no logged-in admin)
+     * @return the audit record describing what was moved
+     */
+    EPersonMergeAudit merge(Context context, EPerson from, EPerson to, EPerson performedBy)
+        throws SQLException, AuthorizeException;
+}

--- a/dspace-api/src/main/java/org/dspace/versioning/VersioningServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersioningServiceImpl.java
@@ -19,6 +19,7 @@ import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
 import org.dspace.versioning.dao.VersionDAO;
 import org.dspace.versioning.service.VersionHistoryService;
 import org.dspace.versioning.service.VersioningService;
@@ -269,5 +270,10 @@ public class VersioningServiceImpl implements VersioningService {
     @Override
     public void deleteVersion(Context c, Version version) throws SQLException {
         versionDAO.delete(c, version);
+    }
+
+    @Override
+    public List<Version> findByEPerson(Context context, EPerson ePerson) throws SQLException {
+        return versionDAO.findByEPerson(context, ePerson);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/versioning/dao/VersionDAO.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/dao/VersionDAO.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.core.GenericDAO;
+import org.dspace.eperson.EPerson;
 import org.dspace.versioning.Version;
 import org.dspace.versioning.VersionHistory;
 
@@ -26,6 +27,11 @@ import org.dspace.versioning.VersionHistory;
  */
 public interface VersionDAO extends GenericDAO<Version> {
     public Version findByItem(Context context, Item item) throws SQLException;
+
+    /**
+     * All versions attributed to an EPerson (used by {@code eperson-merge}).
+     */
+    public List<Version> findByEPerson(Context context, EPerson ePerson) throws SQLException;
 
     /**
      * This method returns all versions of an version history that have items

--- a/dspace-api/src/main/java/org/dspace/versioning/dao/impl/VersionDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/dao/impl/VersionDAOImpl.java
@@ -18,6 +18,7 @@ import javax.persistence.criteria.Root;
 import org.dspace.content.Item;
 import org.dspace.core.AbstractHibernateDAO;
 import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
 import org.dspace.versioning.Version;
 import org.dspace.versioning.VersionHistory;
 import org.dspace.versioning.Version_;
@@ -47,6 +48,16 @@ public class VersionDAOImpl extends AbstractHibernateDAO<Version> implements Ver
         criteriaQuery.select(versionRoot);
         criteriaQuery.where(criteriaBuilder.equal(versionRoot.get(Version_.item), item));
         return singleResult(context, criteriaQuery);
+    }
+
+    @Override
+    public List<Version> findByEPerson(Context context, EPerson ePerson) throws SQLException {
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, Version.class);
+        Root<Version> versionRoot = criteriaQuery.from(Version.class);
+        criteriaQuery.select(versionRoot);
+        criteriaQuery.where(criteriaBuilder.equal(versionRoot.get(Version_.ePerson), ePerson));
+        return list(context, criteriaQuery, false, Version.class, -1, -1);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/versioning/service/VersioningService.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/service/VersioningService.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import org.dspace.content.Item;
 import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
 import org.dspace.versioning.Version;
 import org.dspace.versioning.VersionHistory;
 
@@ -111,5 +112,14 @@ public interface VersioningService {
      * @throws SQLException      If database error
      */
     public int countVersionsByHistoryWithItem(Context context, VersionHistory versionHistory) throws SQLException;
+
+    /**
+     * All versions attributed to an EPerson (used by {@code eperson-merge}).
+     *
+     * @param context context
+     * @param ePerson EPerson
+     * @throws SQLException if database error
+     */
+    List<Version> findByEPerson(Context context, EPerson ePerson) throws SQLException;
 
 }

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2026.07.16__eperson_merge_audit.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2026.07.16__eperson_merge_audit.sql
@@ -1,0 +1,21 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- Audit trail for the eperson-merge tool. Kept even if one side is later
+-- deleted, so from_eperson/to_eperson are plain UUIDs, not FKs.
+
+CREATE SEQUENCE eperson_merge_audit_id_seq START WITH 1 INCREMENT BY 1;
+
+CREATE TABLE eperson_merge_audit (
+    eperson_merge_audit_id INTEGER NOT NULL DEFAULT NEXTVAL('eperson_merge_audit_id_seq') PRIMARY KEY,
+    from_eperson UUID NOT NULL,
+    to_eperson   UUID NOT NULL,
+    performed_by UUID,
+    performed_at TIMESTAMP NOT NULL,
+    detail       CLOB NOT NULL
+);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2026.07.16__eperson_merge_audit.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2026.07.16__eperson_merge_audit.sql
@@ -1,0 +1,30 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- Audit trail for the eperson-merge tool. Kept even if one side is later
+-- deleted, so from_eperson/to_eperson are plain UUIDs, not FKs.
+
+CREATE TABLE eperson_merge_audit (
+    eperson_merge_audit_id integer NOT NULL PRIMARY KEY,
+    from_eperson UUID NOT NULL,
+    to_eperson   UUID NOT NULL,
+    performed_by UUID,
+    performed_at TIMESTAMP NOT NULL,
+    detail       TEXT NOT NULL
+);
+
+CREATE SEQUENCE eperson_merge_audit_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MAXVALUE
+    NO MINVALUE
+    CACHE 1;
+
+ALTER TABLE eperson_merge_audit
+  ALTER COLUMN eperson_merge_audit_id
+    SET DEFAULT nextval('eperson_merge_audit_id_seq');

--- a/dspace-api/src/test/java/org/dspace/eperson/clarin/EPersonMergeServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/clarin/EPersonMergeServiceTest.java
@@ -191,6 +191,37 @@ public class EPersonMergeServiceTest extends AbstractIntegrationTestWithDatabase
     }
 
     @Test
+    public void mergeMovesOnlyOneOfIdenticalDuplicatePoliciesFromSource() throws Exception {
+        context.turnOffAuthorisationSystem();
+        ResourcePolicyBuilder.createResourcePolicy(context, from, null)
+            .withAction(Constants.READ)
+            .withDspaceObject(collection)
+            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
+            .build();
+        // A second policy on `from`, identical in every field the signature considers - `to`
+        // holds none for this object/action, so both would previously have been moved onto it.
+        ResourcePolicyBuilder.createResourcePolicy(context, from, null)
+            .withAction(Constants.READ)
+            .withDspaceObject(collection)
+            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
+            .build();
+        context.restoreAuthSystemState();
+
+        ResourcePolicyService resourcePolicyService = org.dspace.authorize.factory.AuthorizeServiceFactory
+            .getInstance().getResourcePolicyService();
+
+        context.turnOffAuthorisationSystem();
+        ePersonMergeService.merge(context, from, to, admin);
+        context.restoreAuthSystemState();
+
+        long toPoliciesForCollection = resourcePolicyService.findByEPerson(context, to, -1, -1).stream()
+            .filter(rp -> collection.equals(rp.getdSpaceObject()) && rp.getAction() == Constants.READ)
+            .count();
+        assertEquals("only one of the two identical `from` policies should have been moved onto `to`",
+            1, toPoliciesForCollection);
+    }
+
+    @Test
     public void mergeTombstonesFromAndWritesAudit() throws Exception {
         context.turnOffAuthorisationSystem();
         identityService.attach(context, from, "novak@cuni.cz[https://cas.cuni.cz/idp/shibboleth]",

--- a/dspace-api/src/test/java/org/dspace/eperson/clarin/EPersonMergeServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/clarin/EPersonMergeServiceTest.java
@@ -1,0 +1,235 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.eperson.clarin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.EPersonBuilder;
+import org.dspace.builder.GroupBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.builder.ResourcePolicyBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.EPersonService;
+import org.dspace.eperson.service.GroupService;
+import org.dspace.eperson.service.clarin.ClarinIdentityService;
+import org.dspace.eperson.service.clarin.EPersonMergeService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Covers the core FK re-pointing/dedupe/tombstone/audit mechanics of {@link EPersonMergeService}.
+ * Not every table in the design's merge inventory has a dedicated test here (workflow tables,
+ * subscriptions, orcid/clarin tokens, etc. follow the same re-point-or-skip-duplicate pattern
+ * exercised below for item submitter, group membership and resourcepolicy).
+ */
+public class EPersonMergeServiceTest extends AbstractIntegrationTestWithDatabase {
+
+    private EPersonMergeService ePersonMergeService;
+    private ClarinIdentityService identityService;
+    private GroupService groupService;
+    private EPersonService ePersonService;
+
+    private EPerson from;
+    private EPerson to;
+    private Collection collection;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        ePersonMergeService = EPersonServiceFactory.getInstance().getEPersonMergeService();
+        identityService = EPersonServiceFactory.getInstance().getClarinIdentityService();
+        groupService = EPersonServiceFactory.getInstance().getGroupService();
+        ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
+
+        context.turnOffAuthorisationSystem();
+        from = EPersonBuilder.createEPerson(context).withEmail("from@example.org").build();
+        to = EPersonBuilder.createEPerson(context).withEmail("to@example.org").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context).build();
+        collection = CollectionBuilder.createCollection(context, parentCommunity).build();
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Alias rows are not builder-tracked, so an alias left attached to `from` or `to` (either
+     * directly attached by a test, or re-pointed onto `to` by {@code merge}'s alias reassignment)
+     * would make the superclass's {@code destroy()} fail with a foreign-key violation when it
+     * deletes those builder-created EPersons. JUnit runs subclass {@code @After} methods before
+     * superclass ones, so detaching here always runs before that deletion.
+     */
+    @After
+    public void cleanupNetidAliases() throws Exception {
+        context.turnOffAuthorisationSystem();
+        for (EPersonNetidAlias alias : identityService.findAliases(context, from)) {
+            identityService.detach(context, alias);
+        }
+        for (EPersonNetidAlias alias : identityService.findAliases(context, to)) {
+            identityService.detach(context, alias);
+        }
+        context.restoreAuthSystemState();
+    }
+
+    @Test
+    public void mergeReassignsItemSubmitter() throws Exception {
+        context.turnOffAuthorisationSystem();
+        context.setCurrentUser(from);
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Submitted by from").build();
+        context.setCurrentUser(admin);
+        context.restoreAuthSystemState();
+
+        context.turnOffAuthorisationSystem();
+        ePersonMergeService.merge(context, from, to, admin);
+        context.restoreAuthSystemState();
+
+        assertEquals(to, item.getSubmitter());
+    }
+
+    @Test
+    public void mergeUnionsGroupMembershipAndSkipsDuplicates() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Group onlyFromGroup = GroupBuilder.createGroup(context).withName("only-from").build();
+        Group sharedGroup = GroupBuilder.createGroup(context).withName("shared").build();
+        groupService.addMember(context, onlyFromGroup, from);
+        groupService.addMember(context, sharedGroup, from);
+        groupService.addMember(context, sharedGroup, to);
+        context.restoreAuthSystemState();
+
+        context.turnOffAuthorisationSystem();
+        ePersonMergeService.merge(context, from, to, admin);
+        context.restoreAuthSystemState();
+
+        assertTrue("to should have joined from's exclusive group",
+            groupService.isDirectMember(onlyFromGroup, to));
+        assertFalse("from should no longer be a member of any group it held",
+            groupService.isDirectMember(onlyFromGroup, from));
+        assertFalse("from's membership in the shared group should be removed, not duplicated",
+            groupService.isDirectMember(sharedGroup, from));
+    }
+
+    @Test
+    public void mergeSkipsDuplicateResourcePolicies() throws Exception {
+        context.turnOffAuthorisationSystem();
+        ResourcePolicyBuilder.createResourcePolicy(context, from, null)
+            .withAction(Constants.READ)
+            .withDspaceObject(collection)
+            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context, to, null)
+            .withAction(Constants.READ)
+            .withDspaceObject(collection)
+            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
+            .build();
+        context.restoreAuthSystemState();
+
+        ResourcePolicyService resourcePolicyService = org.dspace.authorize.factory.AuthorizeServiceFactory
+            .getInstance().getResourcePolicyService();
+        int toPoliciesBefore = resourcePolicyService.findByEPerson(context, to, -1, -1).size();
+
+        context.turnOffAuthorisationSystem();
+        ePersonMergeService.merge(context, from, to, admin);
+        context.restoreAuthSystemState();
+
+        int toPoliciesAfter = resourcePolicyService.findByEPerson(context, to, -1, -1).size();
+        assertEquals("the duplicate policy should have been skipped, not duplicated onto `to`",
+            toPoliciesBefore, toPoliciesAfter);
+    }
+
+    @Test
+    public void mergeMovesResourcePoliciesThatOnlyDifferByDates() throws Exception {
+        context.turnOffAuthorisationSystem();
+        java.util.Date start = new java.util.Date(0);
+        java.util.Date end = new java.util.Date(1_000_000_000L);
+        ResourcePolicyBuilder.createResourcePolicy(context, from, null)
+            .withAction(Constants.READ)
+            .withDspaceObject(collection)
+            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
+            .withStartDate(start)
+            .withEndDate(end)
+            .build();
+        // `to` already has a policy for the same object/action/type but with no dates - it must
+        // NOT be treated as a duplicate of the dated policy above, since the access semantics
+        // differ (time-limited vs. unlimited).
+        ResourcePolicyBuilder.createResourcePolicy(context, to, null)
+            .withAction(Constants.READ)
+            .withDspaceObject(collection)
+            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
+            .build();
+        context.restoreAuthSystemState();
+
+        ResourcePolicyService resourcePolicyService = org.dspace.authorize.factory.AuthorizeServiceFactory
+            .getInstance().getResourcePolicyService();
+        int toPoliciesBefore = resourcePolicyService.findByEPerson(context, to, -1, -1).size();
+
+        context.turnOffAuthorisationSystem();
+        ePersonMergeService.merge(context, from, to, admin);
+        context.restoreAuthSystemState();
+
+        int toPoliciesAfter = resourcePolicyService.findByEPerson(context, to, -1, -1).size();
+        assertEquals("the dated policy differs in access semantics and must be moved, not skipped",
+            toPoliciesBefore + 1, toPoliciesAfter);
+    }
+
+    @Test
+    public void mergeTombstonesFromAndWritesAudit() throws Exception {
+        context.turnOffAuthorisationSystem();
+        identityService.attach(context, from, "novak@cuni.cz[https://cas.cuni.cz/idp/shibboleth]",
+            "migration", null);
+        context.restoreAuthSystemState();
+
+        context.turnOffAuthorisationSystem();
+        EPersonMergeAudit audit = ePersonMergeService.merge(context, from, to, admin);
+        context.restoreAuthSystemState();
+
+        assertFalse("tombstoned account must not be able to log in", from.canLogIn());
+        assertTrue("from's email should be parked, freeing the original for reuse",
+            from.getEmail().contains("from@example.org") && !from.getEmail().equals("from@example.org"));
+        assertEquals(to, identityService.resolve(context,
+            "novak@cuni.cz[https://cas.cuni.cz/idp/shibboleth]"));
+
+        assertNotNull(audit);
+        assertEquals(from.getID(), audit.getFromEPerson());
+        assertEquals(to.getID(), audit.getToEPerson());
+        assertEquals(admin.getID(), audit.getPerformedBy());
+        assertTrue(audit.getDetail().contains("item.submitter"));
+    }
+
+    @Test
+    public void mergeTombstonesFromWithLongEmailWithoutExceedingColumnLength() throws Exception {
+        String longLocalPart = StringUtils.repeat('a', 80);
+        String longEmail = longLocalPart + "@example.org";
+        context.turnOffAuthorisationSystem();
+        from.setEmail(longEmail);
+        ePersonService.update(context, from);
+        context.restoreAuthSystemState();
+
+        context.turnOffAuthorisationSystem();
+        ePersonMergeService.merge(context, from, to, admin);
+        context.restoreAuthSystemState();
+
+        assertTrue("parked email must fit in the eperson.email column (64 chars)",
+            from.getEmail().length() <= 64);
+        assertFalse("from's email must actually have changed away from the original (too long) address",
+            from.getEmail().equals(longEmail));
+    }
+}

--- a/dspace/config/hibernate.cfg.xml
+++ b/dspace/config/hibernate.cfg.xml
@@ -83,6 +83,7 @@
         <mapping class="org.dspace.content.clarin.ClarinToken"/>
         <mapping class="org.dspace.content.ReportResult"/>
         <mapping class="org.dspace.eperson.clarin.EPersonNetidAlias"/>
+        <mapping class="org.dspace.eperson.clarin.EPersonMergeAudit"/>
 
         <mapping class="org.dspace.harvest.HarvestedCollection"/>
         <mapping class="org.dspace.harvest.HarvestedItem"/>

--- a/dspace/config/spring/api/core-dao-services.xml
+++ b/dspace/config/spring/api/core-dao-services.xml
@@ -59,6 +59,7 @@
     <bean class="org.dspace.content.dao.impl.clarin.ClarinTokenDAOImpl"/>
     <bean class="org.dspace.content.dao.impl.ReportResultDAOImpl"/>
     <bean class="org.dspace.eperson.dao.impl.clarin.EPersonNetidAliasDAOImpl"/>
+    <bean class="org.dspace.eperson.dao.impl.clarin.EPersonMergeAuditDAOImpl"/>
 
     <bean class="org.dspace.harvest.dao.impl.HarvestedItemDAOImpl"/>
     <bean class="org.dspace.harvest.dao.impl.HarvestedCollectionDAOImpl"/>

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -99,6 +99,8 @@
     <bean class="org.dspace.content.clarin.ClarinTokenServiceImpl"/>
     <bean class="org.dspace.content.ReportResultServiceImpl"/>
     <bean class="org.dspace.eperson.clarin.ClarinIdentityServiceImpl"/>
+    <bean class="org.dspace.eperson.clarin.EPersonMergeAuditServiceImpl"/>
+    <bean class="org.dspace.eperson.clarin.EPersonMergeServiceImpl"/>
 
     <bean class="org.dspace.core.NewsServiceImpl">
         <property name="acceptableFilenames">

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -56,6 +56,12 @@
         <property name="dspaceRunnableClass" value="org.dspace.administer.ProcessCleanerCli"/>
     </bean>
 
+    <bean id="eperson-merge" class="org.dspace.administer.EPersonMergeCliConfiguration">
+        <property name="description"
+                  value="Merge two duplicate EPerson accounts: re-point ownership from --from to --to, tombstone --from"/>
+        <property name="dspaceRunnableClass" value="org.dspace.administer.EPersonMergeCli"/>
+    </bean>
+
     <bean id="filter-media" class="org.dspace.app.mediafilter.MediaFilterScriptConfiguration">
         <property name="description" value="Perform the media filtering to extract full text from documents and to create thumbnails"/>
         <property name="dspaceRunnableClass" value="org.dspace.app.mediafilter.MediaFilterScript"/>


### PR DESCRIPTION
Adds an EPersonMerge admin tool (CLI + REST via the scripts framework, `eperson-merge`) that re-points FKs from a duplicate account to the surviving one via the service layer, tombstones the source account (canLogIn=false, email parked), and records every merge in a new eperson_merge_audit table, since duplicates are otherwise unavoidable while multiple netid-writing auth paths (Shib, LDAP, ORCID, OIDC) remain unconverted.

> [!IMPORTANT]
> Stacked on #1382 (identity linking) — the merge tool re-points netid aliases through ClarinIdentityService. Base is `identity-linking`; retarget to `clarin-v7` once #1382 merges.

## Problem description

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.)

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot

