### PR TITLE
CI: redeploy ok-dspace on pushes to clarin-v7

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -154,14 +154,16 @@ jobs:
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
   ###########################################################################
-  # Redeploy the ok-dspace test environment (ufal/dspace-k8s, ns kosarko-ns)
+  # Notify ufal/dspace-k8s of a new build, for the ok-dspace test environment
   ###########################################################################
-  # Runs only for pushes to the default branch, after the images this
-  # environment consumes have actually been pushed. This job only records the
-  # new version: it sends a repository_dispatch to ufal/dspace-k8s, which pins
-  # the tag to git, and a reconciler inside the cluster picks it up. No
-  # deployment step and no cluster credential exists in this repository - or in
-  # GitHub at all.
+  # Runs only for pushes to `clarin-v7` - currently the default branch, named
+  # explicitly here because that is exactly what the guard below matches - and
+  # only after the images this environment consumes have actually been pushed.
+  #
+  # This job records a new version; it does not deploy. It sends a
+  # repository_dispatch to ufal/dspace-k8s, which pins the tag to git, and a
+  # reconciler inside that cluster applies it. No deployment step and no cluster
+  # credential exists in this repository, or anywhere in GitHub.
   deploy-ok-dspace:
     if: github.repository == 'ufal/clarin-dspace' && github.event_name == 'push' && github.ref_name == 'clarin-v7'
     # Both images are built from this same commit, so ok-dspace pins one SHA
@@ -169,7 +171,7 @@ jobs:
     needs: [dspace, dspace-solr]
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger deployment
+      - name: Notify ufal/dspace-k8s
         uses: peter-evans/repository-dispatch@v4
         with:
           # Fine-grained PAT, scoped to ufal/dspace-k8s only, Contents: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -152,3 +152,29 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+  ###########################################################################
+  # Redeploy the ok-dspace test environment (ufal/dspace-k8s, ns kosarko-ns)
+  ###########################################################################
+  # Runs only for pushes to the default branch, after the images this
+  # environment consumes have actually been pushed. This job only records the
+  # new version: it sends a repository_dispatch to ufal/dspace-k8s, which pins
+  # the tag to git, and a reconciler inside the cluster picks it up. No
+  # deployment step and no cluster credential exists in this repository - or in
+  # GitHub at all.
+  deploy-ok-dspace:
+    if: github.repository == 'ufal/clarin-dspace' && github.event_name == 'push' && github.ref_name == 'clarin-v7'
+    # Both images are built from this same commit, so ok-dspace pins one SHA
+    # for the pair. Waiting for both avoids dispatching a half-built version.
+    needs: [dspace, dspace-solr]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger deployment
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          # Fine-grained PAT, scoped to ufal/dspace-k8s only, Contents: write
+          # (what POST /repos/{owner}/{repo}/dispatches requires).
+          token: ${{ secrets.OK_DSPACE_DEPLOY_TOKEN }}
+          repository: ufal/dspace-k8s
+          event-type: deploy-ok-dspace
+          client-payload: '{"component":"backend","sha":"${{ github.sha }}"}'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -171,16 +171,24 @@ jobs:
     needs: [dspace, dspace-solr]
     runs-on: ubuntu-latest
     # This job authenticates with a PAT and never uses GITHUB_TOKEN, so it needs
-    # none of the workflow-level permissions. Dropping them limits what a
-    # compromised third-party action could reach from here.
+    # none of the workflow-level permissions at all.
     permissions: {}
     steps:
+      # One POST, hand-rolled with the `gh` and `jq` that ubuntu-latest already
+      # ships, rather than a third-party dispatch action: a single API call is
+      # not worth a supply-chain dependency that runs with the PAT in its
+      # environment.
       - name: Notify ufal/dspace-k8s
-        uses: peter-evans/repository-dispatch@v4
-        with:
+        env:
           # Fine-grained PAT, scoped to ufal/dspace-k8s only, Contents: write
           # (what POST /repos/{owner}/{repo}/dispatches requires).
-          token: ${{ secrets.OK_DSPACE_DEPLOY_TOKEN }}
-          repository: ufal/dspace-k8s
-          event-type: deploy-ok-dspace
-          client-payload: '{"component":"backend","sha":"${{ github.sha }}"}'
+          GH_TOKEN: ${{ secrets.OK_DSPACE_DEPLOY_TOKEN }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # jq builds the payload from an --arg, so the value is a JSON string
+          # by construction rather than by careful quoting.
+          jq -n --arg sha "${SHA}" \
+            '{event_type: "deploy-ok-dspace",
+              client_payload: {component: "backend", sha: $sha}}' \
+            | gh api -X POST repos/ufal/dspace-k8s/dispatches --input -

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -170,6 +170,10 @@ jobs:
     # for the pair. Waiting for both avoids dispatching a half-built version.
     needs: [dspace, dspace-solr]
     runs-on: ubuntu-latest
+    # This job authenticates with a PAT and never uses GITHUB_TOKEN, so it needs
+    # none of the workflow-level permissions. Dropping them limits what a
+    # compromised third-party action could reach from here.
+    permissions: {}
     steps:
       - name: Notify ufal/dspace-k8s
         uses: peter-evans/repository-dispatch@v4


### PR DESCRIPTION
Appends a `deploy-ok-dspace` job to `docker.yml` that notifies
[`ufal/dspace-k8s`](https://github.com/ufal/dspace-k8s) once the images this test environment
consumes have been pushed. Target environment: <https://ok-dspace.dyn.cloud.e-infra.cz>.

**This job records a version; it does not deploy.** It sends a `repository_dispatch`; `dspace-k8s`
pins the tag to git and a reconciler inside the cluster applies it. No deployment step and no cluster
credential exists in this repository — or anywhere in GitHub.

- `needs: [dspace, dspace-solr]` — both images build from this same commit, so ok-dspace pins one
  SHA for the pair; waiting for both avoids dispatching a half-built version.
- Runs only for **pushes to `clarin-v7` in `ufal/clarin-dspace`**, so a pull request builds images
  but never triggers a deploy, and forks never fire it.
- `secrets.OK_DSPACE_DEPLOY_TOKEN` is a fine-grained PAT scoped to `ufal/dspace-k8s` with
  **Contents: write**, which is what `POST /repos/{owner}/{repo}/dispatches` requires. It is already
  configured as an organisation secret. A workflow's own `GITHUB_TOKEN` cannot act on another
  repository, so this credential is unavoidable.

Nothing else in the build changes.

**Depends on** ufal/dspace-k8s#39, which defines the `deploy-ok-dspace` dispatch type. This PR is
inert until that merges — the dispatch simply has no listener.
