### PR TITLE
HuggingFace Facade fixes, to work with llama

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/hf/ClarinHuggingFaceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/hf/ClarinHuggingFaceController.java
@@ -203,6 +203,23 @@ public class ClarinHuggingFaceController {
         }
     }
 
+    @GetMapping("/api/models/{prefix}/{suffix}/refs")
+    public ResponseEntity<Object> refs(@PathVariable String prefix, @PathVariable String suffix,
+                                       HttpServletRequest request) throws SQLException {
+        if (!huggingFaceService.isEnabled()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        try {
+            return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(
+                    "{\"branches\": [ {\"name\": \"main\", \"ref\": \"refs/heads/main\", " +
+                    "\"targetCommit\": \"3a8c0b1456843b87a61c5c9e1996903ea740ea15\" }]," +
+                    "\"converts\": [], \"tags\": [] }");
+        } catch (HuggingFaceApiException e) {
+            return e.toResponse();
+        }
+    }
+
     /**
      * List exposed Items ("models"), HuggingFace-Hub {@code GET /api/models} style.
      *

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/hf/ClarinHuggingFaceService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/hf/ClarinHuggingFaceService.java
@@ -444,7 +444,7 @@ public class ClarinHuggingFaceService {
             treeEntry.setType("file");
             treeEntry.setPath(entry.getKey());
             treeEntry.setSize(entry.getValue().getSizeBytes());
-            treeEntry.setOid(entry.getValue().getChecksum());
+            treeEntry.setOid(DigestUtils.sha1Hex(entry.getKey() + "\n" + entry.getValue().getChecksum()));
             entries.add(treeEntry);
         }
         return entries;


### PR DESCRIPTION
In order to make llama work against item (with LLM stored as bitstream) in DSpace:

`llama serve --port {web UI port} -hf {prefix}/{suffix}`

I had to implement

`GET /server/api/hf/api/models/{prefix}/{suffix}/refs` endpoint 

(hardcoded implementation),

and fix

`GET /server/api/hf/api/models/{prefix}/{suffix}/tree/{revision}` endpoint 

to return **oid** property as SH1 (40 chars HEX string), e.g.:
```
[
    {
        "type": "file",
        "path": "Qwen3-8B-Q4_K_M.gguf",
        "size": 5027783488,
        "oid": "50fda0aab982c91747b7c96e5941c55c8d3f9a1e"
    }
]
```